### PR TITLE
Add CreateProduct endpoints (regular, swap, wanted)

### DIFF
--- a/src/backend/ReUse.API/Controllers/ProductController.cs
+++ b/src/backend/ReUse.API/Controllers/ProductController.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 
+using ReUse.API.Extensions;
+using ReUse.Application.DTOs.Products.Requests;
 using ReUse.Application.Interfaces.Services;
 namespace ReUse.API.Controllers;
 
@@ -8,23 +10,46 @@ namespace ReUse.API.Controllers;
 public class ProductController : ControllerBase
 {
     private readonly IProductImageService _productImageService;
-    public ProductController(IProductImageService productImageService)
+    private readonly IProductService _productService;
+    public ProductController(IProductImageService productImageService, IProductService productService)
     {
         _productImageService = productImageService;
+        _productService = productService;
     }
-    //[HttpPost]
-    //public async Task<IActionResult> UploadImages(
-    // [FromForm] ProductImageCommand request)
-    //{
 
-    //    var result = await _productImageService.UploadMultipleImagesAsync(request);
+    [HttpPost("regular")]
+    [Consumes("multipart/form-data")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> CreateRegularProduct([FromForm] CreateRegularProductRequest request)
+    {
+        var sellerId = User.GetBusinessId();
+        var result = await _productService.CreateRegularProductAsync(request, sellerId);
+        return Ok(result);
 
-    //    return Ok(new
-    //    {
-    //        Message = "Images uploaded successfully",
-    //        Images = result
-    //    });
-    //
-    //}
+    }
+
+    [HttpPost("swap")]
+    [Consumes("multipart/form-data")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> CreateSwapProduct([FromForm] CreateSwapProductRequest request)
+    {
+        var sellerId = User.GetBusinessId();
+
+        var result = await _productService.CreateSwapProductAsync(request, sellerId);
+
+        return Ok(result);
+    }
+
+    [HttpPost("wanted")]
+    [Consumes("multipart/form-data")]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> CreateWantedProduct([FromForm] CreateWantedProductRequest request)
+    {
+        var sellerId = User.GetBusinessId();
+
+        var result = await _productService.CreateWantedProductAsync(request, sellerId);
+
+        return Ok(result);
+    }
 
 }

--- a/src/backend/ReUse.Application/DTOs/Products/Requests/BasicInfoRequest.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Requests/BasicInfoRequest.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using ReUse.Domain.Enums;
+
+namespace ReUse.Application.DTOs.Products.Requests;
+
+public record BasicInfoRequest(
+    string Title,
+    string Description,
+    Guid CategoryId,
+    ProductCondition Condition
+);

--- a/src/backend/ReUse.Application/DTOs/Products/Requests/BasicInfoValidator.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Requests/BasicInfoValidator.cs
@@ -1,0 +1,25 @@
+﻿using FluentValidation;
+
+using ReUse.Application.DTOs.Products.Requests;
+
+namespace ReUse.Application.DTOs.Products.Requests;
+
+public class BasicInfoValidator : AbstractValidator<BasicInfoRequest>
+{
+    public BasicInfoValidator()
+    {
+        RuleFor(x => x.Title)
+            .NotEmpty().WithMessage("Title is required")
+            .MaximumLength(100).WithMessage("Title must not exceed 100 characters");
+
+        RuleFor(x => x.Description)
+            .NotEmpty().WithMessage("Description is required")
+            .MaximumLength(1000).WithMessage("Description must not exceed 1000 characters");
+
+        RuleFor(x => x.CategoryId)
+            .NotEmpty().WithMessage("CategoryId is required");
+
+        RuleFor(x => x.Condition)
+            .IsInEnum().WithMessage("Invalid product condition");
+    }
+}

--- a/src/backend/ReUse.Application/DTOs/Products/Requests/CreateRegularProductRequest.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Requests/CreateRegularProductRequest.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http;
+
+namespace ReUse.Application.DTOs.Products.Requests;
+
+public record CreateRegularProductRequest(
+    BasicInfoRequest BasicInfo,
+    decimal Price,
+    bool AllowNegotiation,
+     List<IFormFile> Images
+    );

--- a/src/backend/ReUse.Application/DTOs/Products/Requests/CreateRegularProductValidator.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Requests/CreateRegularProductValidator.cs
@@ -1,0 +1,40 @@
+﻿using FluentValidation;
+
+using ReUse.Application.DTOs.Products.Requests;
+
+namespace ReUse.Application.DTOs.Products.Requests;
+
+public class CreateRegularProductValidator : AbstractValidator<CreateRegularProductRequest>
+{
+    public CreateRegularProductValidator()
+    {
+        RuleFor(x => x.BasicInfo)
+            .NotNull().WithMessage("BasicInfo is required")
+            .SetValidator(new BasicInfoValidator());
+
+        RuleFor(x => x.Price)
+            .GreaterThan(0).WithMessage("Price must be greater than 0")
+            .LessThanOrEqualTo(1_000_000).WithMessage("Price is too high");
+
+        RuleFor(x => x.AllowNegotiation)
+            .NotNull();
+
+
+        RuleFor(x => x.Images)
+            .NotNull().WithMessage("Images are required")
+            .Must(images => images != null && images.Count > 0)
+            .WithMessage("At least one image is required")
+            .Must(images => images != null && images.Count <= 10)
+            .WithMessage("You can upload up to 10 images only");
+
+
+        When(x => x.Images != null, () =>
+        {
+            RuleForEach(x => x.Images)
+                .Must(img => img.Length > 0)
+                .WithMessage("Image file cannot be empty")
+                .Must(img => img.Length <= 5 * 1024 * 1024)
+                .WithMessage("Each image must be less than 5MB");
+        });
+    }
+}

--- a/src/backend/ReUse.Application/DTOs/Products/Requests/CreateSwapProductRequest.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Requests/CreateSwapProductRequest.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http;
+
+namespace ReUse.Application.DTOs.Products.Requests;
+
+public record CreateSwapProductRequest
+(
+    BasicInfoRequest BasicInfo,
+    string WantedItemTitle,
+    string WantedItemDescription,
+    List<IFormFile> OfferImages,
+    List<IFormFile>? WantedImages
+);

--- a/src/backend/ReUse.Application/DTOs/Products/Requests/CreateSwapProductValidator.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Requests/CreateSwapProductValidator.cs
@@ -1,0 +1,64 @@
+﻿using FluentValidation;
+
+using ReUse.Application.DTOs.Products.Requests;
+
+namespace ReUse.Application.DTOs.Products.Requests;
+
+public class CreateSwapProductValidator : AbstractValidator<CreateSwapProductRequest>
+{
+    public CreateSwapProductValidator()
+    {
+        RuleFor(x => x.BasicInfo)
+            .NotNull().WithMessage("BasicInfo is required")
+            .SetValidator(new BasicInfoValidator());
+
+        RuleFor(x => x.WantedItemTitle)
+            .NotEmpty().WithMessage("Wanted item title is required")
+            .MaximumLength(100);
+
+        RuleFor(x => x.WantedItemDescription)
+            .NotEmpty().WithMessage("Wanted item description is required")
+            .MaximumLength(1000);
+
+        //OFFER IMAGES 
+        RuleFor(x => x.OfferImages)
+            .NotNull().WithMessage("Offer images are required")
+            .Must(images => images != null && images.Any())
+            .WithMessage("At least one offer image is required")
+            .Must(images => images != null && images.Count <= 10)
+            .WithMessage("You can upload up to 10 offer images only");
+
+        When(x => x.OfferImages != null && x.OfferImages.Any(), () =>
+        {
+            RuleForEach(x => x.OfferImages!)
+                .ChildRules(img =>
+                {
+                    img.RuleFor(x => x.Length)
+                        .GreaterThan(0)
+                        .WithMessage("Offer image file cannot be empty");
+
+                    img.RuleFor(x => x.Length)
+                        .LessThanOrEqualTo(5 * 1024 * 1024)
+                        .WithMessage("Each offer image must be less than 5MB");
+                });
+        });
+
+        // WANTED IMAGES 
+        When(x => x.WantedImages != null && x.WantedImages.Any(), () =>
+        {
+            RuleFor(x => x.WantedImages!)
+                .Must(images => images.Count <= 10)
+                .WithMessage("You can upload up to 10 wanted images only");
+
+            RuleForEach(x => x.WantedImages!)
+                .ChildRules(img =>
+                {
+                    img.RuleFor(x => x.Length)
+                        .GreaterThan(0);
+
+                    img.RuleFor(x => x.Length)
+                        .LessThanOrEqualTo(5 * 1024 * 1024);
+                });
+        });
+    }
+}

--- a/src/backend/ReUse.Application/DTOs/Products/Requests/CreateWantedProductRequest.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Requests/CreateWantedProductRequest.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http;
+
+namespace ReUse.Application.DTOs.Products.Requests;
+
+public record CreateWantedProductRequest
+(
+    BasicInfoRequest BasicInfo,
+    decimal DesiredPriceMin,
+    decimal DesiredPriceMax,
+    //   ShippingRequest? Shipping,
+    List<IFormFile> Images
+);

--- a/src/backend/ReUse.Application/DTOs/Products/Requests/CreateWantedProductValidator.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Requests/CreateWantedProductValidator.cs
@@ -1,0 +1,42 @@
+﻿using FluentValidation;
+
+using ReUse.Application.DTOs.Products.Requests;
+
+namespace ReUse.Application.DTOs.Products.Requests;
+
+public class CreateWantedProductValidator : AbstractValidator<CreateWantedProductRequest>
+{
+    public CreateWantedProductValidator()
+    {
+
+        RuleFor(x => x.BasicInfo)
+            .NotNull().WithMessage("BasicInfo is required")
+            .SetValidator(new BasicInfoValidator());
+
+
+        RuleFor(x => x.DesiredPriceMin)
+            .GreaterThan(0).WithMessage("Minimum desired price must be greater than 0");
+
+
+        RuleFor(x => x.DesiredPriceMax)
+            .GreaterThan(0).WithMessage("Maximum desired price must be greater than 0");
+
+
+        RuleFor(x => x)
+            .Must(x => x.DesiredPriceMax >= x.DesiredPriceMin)
+            .WithMessage("Maximum price must be greater than or equal to minimum price");
+
+
+        RuleFor(x => x.Images)
+            .NotNull().WithMessage("Images are required")
+            .NotEmpty().WithMessage("At least one image is required")
+            .Must(images => images.Count <= 10)
+            .WithMessage("You can upload up to 10 images only");
+
+        RuleForEach(x => x.Images)
+            .Must(img => img.Length > 0)
+            .WithMessage("Image file cannot be empty")
+            .Must(img => img.Length <= 5 * 1024 * 1024)
+            .WithMessage("Each image must be less than 5MB");
+    }
+}

--- a/src/backend/ReUse.Application/DTOs/Products/Requests/ShippingRequest.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Requests/ShippingRequest.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReUse.Application.DTOs.Products.Requests;
+
+public record ShippingRequest(
+    //bool OffersShipping,
+    // bool LocalPickup
+    );
+
+
+//TODO: Add shipping method, price, free shipping, weight, and package size to the ShippingRequest record

--- a/src/backend/ReUse.Application/DTOs/Products/Requests/UploadProductImagesRequest.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Requests/UploadProductImagesRequest.cs
@@ -1,10 +1,14 @@
 ﻿using Microsoft.AspNetCore.Http;
 
-namespace ReUse.Application.DTOs.Products;
+using ReUse.Domain.Enums;
+
+
+namespace ReUse.Application.DTOs.Products.Requests;
 
 public record UploadProductImagesRequest
 {
     public Guid Id { get; init; }
     public int Order { get; init; }
+    public ProductImageType Type { get; init; }
     public IReadOnlyList<IFormFile> Images { get; init; } = null!;
 }

--- a/src/backend/ReUse.Application/DTOs/Products/Responses/ProductImageResponse.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Responses/ProductImageResponse.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReUse.Application.DTOs.Products.Responses;
+
+public record ProductImageResponse
+ (
+    Guid Id,
+    string Url,
+    int DisplayOrder
+  );

--- a/src/backend/ReUse.Application/DTOs/Products/Responses/ProductResponse.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Responses/ProductResponse.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using ReUse.Domain.Enums;
+
+namespace ReUse.Application.DTOs.Products.Responses;
+
+public record ProductResponse
+    (
+      Guid Id,
+      ProductType Type,
+      string Title,
+      string Description,
+      Guid CategoryId,
+      ProductCondition? Condition,
+      Guid OwnerUserId,
+      DateTime CreatedAt,
+      // Type-specific
+      decimal? Price, // Regular
+      bool AllowNegotiation, // Regular
+      string? WantedItem,   // Swap
+      string? WantedItemDescription,  // Swap
+      decimal? MinPrice,   // Wanted
+      decimal? MaxPrice,  // Wanted
+
+      //  ShippingResponse? Shipping,
+      List<UploadedImageResponse> Images,
+      string CoverImageUrl
+    );

--- a/src/backend/ReUse.Application/DTOs/Products/Responses/ShippingResponse.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Responses/ShippingResponse.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReUse.Application.DTOs.Products.Responses;
+
+public record ShippingResponse(
+     bool OffersShipping,
+     bool LocalPickup
+);

--- a/src/backend/ReUse.Application/DTOs/Products/Responses/UploadedImageResponse.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Responses/UploadedImageResponse.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReUse.Application.DTOs.Products.Responses;
+
+public record UploadedImageResponse
+(
+    Guid Id,
+    string Url,
+    string PublicId
+);

--- a/src/backend/ReUse.Application/DependencyInjection.cs
+++ b/src/backend/ReUse.Application/DependencyInjection.cs
@@ -25,6 +25,7 @@ public static class DependencyInjection
         services.AddScoped<IFollowService, FollowService>();
         services.AddScoped<IUserService, UserService>();
         services.AddScoped<ICategoryService, CategoryService>();
+        services.AddScoped<IProductService, ProductService>();
         #endregion
 
 

--- a/src/backend/ReUse.Application/Interfaces/IUnitOfWork.cs
+++ b/src/backend/ReUse.Application/Interfaces/IUnitOfWork.cs
@@ -5,10 +5,14 @@ namespace ReUse.Application.Interfaces;
 
 public interface IUnitOfWork : IDisposable
 {
+    Task BeginTransactionAsync();
+    Task CommitTransactionAsync();
+    Task RollbackTransactionAsync();
     IUserRepository User { get; }
     IFollowRepository Follow { get; }
     IProductImageRepository ProductImages { get; }
     ICategoryRepository Category { get; }
+    IProductRepository Product { get; }
     Task<int> SaveChangesAsync();
     void Dispose();
 }

--- a/src/backend/ReUse.Application/Interfaces/Repository/IBaseRepository.cs
+++ b/src/backend/ReUse.Application/Interfaces/Repository/IBaseRepository.cs
@@ -17,5 +17,7 @@ namespace ReUse.Application.Interfaces.Repository
         public void Update(T entity);
         Task AddRangeAsync(IEnumerable<T> entities);
 
+        void RemoveRange(IEnumerable<T> entities);
+
     }
 }

--- a/src/backend/ReUse.Application/Interfaces/Repository/IProductImageRepository.cs
+++ b/src/backend/ReUse.Application/Interfaces/Repository/IProductImageRepository.cs
@@ -13,4 +13,6 @@ public interface IProductImageRepository : IBaseRepository<ProductImage>
     Task<List<ProductImage>> GetByProductIdAsync(Guid productId);
 
     Task<int> CountByProductIdAsync(Guid productId);
+
+    Task<List<ProductImage>> GetByPublicIdsAsync(IEnumerable<string> publicIds);
 }

--- a/src/backend/ReUse.Application/Interfaces/Repository/IProductRepository.cs
+++ b/src/backend/ReUse.Application/Interfaces/Repository/IProductRepository.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using ReUse.Domain.Entities;
+
+namespace ReUse.Application.Interfaces.Repository;
+
+public interface IProductRepository : IBaseRepository<Product>
+{
+}

--- a/src/backend/ReUse.Application/Interfaces/Services/External/ICloudinaryService.cs
+++ b/src/backend/ReUse.Application/Interfaces/Services/External/ICloudinaryService.cs
@@ -8,5 +8,5 @@ public interface ICloudinaryService
 {
     Task<ImageUpdatedResponse> UpdateAsync(IFormFile file, string folder);
     Task DeleteAsync(string publicId);
-
+    Task DeleteMultipleAsync(IEnumerable<string> publicIds);
 }

--- a/src/backend/ReUse.Application/Interfaces/Services/IProductImageService.cs
+++ b/src/backend/ReUse.Application/Interfaces/Services/IProductImageService.cs
@@ -1,8 +1,13 @@
-﻿using ReUse.Application.DTOs.Products;
+﻿using ReUse.Application.DTOs.Products.Requests;
+using ReUse.Application.DTOs.Products.Responses;
 
 namespace ReUse.Application.Interfaces.Services;
 
 public interface IProductImageService
 {
-    public Task<List<string>> UploadMultipleImagesAsync(UploadProductImagesRequest request);
+    public Task<List<UploadedImageResponse>> UploadMultipleImagesAsync(
+     UploadProductImagesRequest request);
+
+    public Task DeleteByPublicIdsAsync(IEnumerable<string> publicIds);
+
 }

--- a/src/backend/ReUse.Application/Interfaces/Services/IProductService.cs
+++ b/src/backend/ReUse.Application/Interfaces/Services/IProductService.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http;
+
+using ReUse.Application.DTOs.Products.Requests;
+using ReUse.Application.DTOs.Products.Responses;
+
+namespace ReUse.Application.Interfaces.Services;
+
+public interface IProductService
+{
+    public Task<ProductResponse> CreateRegularProductAsync(CreateRegularProductRequest request, Guid sellerId);
+    public Task<ProductResponse> CreateSwapProductAsync(CreateSwapProductRequest request, Guid sellerId);
+    public Task<ProductResponse> CreateWantedProductAsync(CreateWantedProductRequest request, Guid sellerId);
+
+}

--- a/src/backend/ReUse.Application/Services/ProductImageService.cs
+++ b/src/backend/ReUse.Application/Services/ProductImageService.cs
@@ -1,4 +1,5 @@
-﻿using ReUse.Application.DTOs.Products;
+﻿using ReUse.Application.DTOs.Products.Requests;
+using ReUse.Application.DTOs.Products.Responses;
 using ReUse.Application.Exceptions;
 using ReUse.Application.Interfaces;
 using ReUse.Application.Interfaces.Services;
@@ -23,7 +24,8 @@ public class ProductImageService : IProductImageService
     }
 
 
-    public async Task<List<string>> UploadMultipleImagesAsync(UploadProductImagesRequest request)
+    public async Task<List<UploadedImageResponse>> UploadMultipleImagesAsync(
+     UploadProductImagesRequest request)
     {
         if (request.Images is null || !request.Images.Any())
             throw new BadRequestException("At least one image is required.");
@@ -39,8 +41,11 @@ public class ProductImageService : IProductImageService
         var uploadResults = await Task.WhenAll(
             files.Select((file, index) =>
                 _cloudinary.UpdateAsync(file, $"products/{request.Id}")
-                    .ContinueWith(t => (Dto: t.Result, Order: existingCount + index),
-                        TaskContinuationOptions.OnlyOnRanToCompletion))
+                    .ContinueWith(t => new
+                    {
+                        Dto = t.Result,
+                        Order = existingCount + index
+                    }, TaskContinuationOptions.OnlyOnRanToCompletion))
         );
 
         try
@@ -51,13 +56,16 @@ public class ProductImageService : IProductImageService
                 ProductId = request.Id,
                 Url = r.Dto.Url,
                 PublicId = r.Dto.PublicId,
-                DisplayOrder = r.Order
+                DisplayOrder = r.Order,
+                Type = request.Type
             }).ToList();
 
             await _unitOfWork.ProductImages.AddRangeAsync(entities);
             await _unitOfWork.SaveChangesAsync();
 
-            return entities.Select(e => e.Url).ToList();
+
+            return entities.Select(e =>
+           new UploadedImageResponse(e.Id, e.Url, e.PublicId)).ToList();
         }
         catch
         {
@@ -69,4 +77,25 @@ public class ProductImageService : IProductImageService
             throw;
         }
     }
+
+    public async Task DeleteByPublicIdsAsync(IEnumerable<string> publicIds)
+    {
+        if (publicIds is null || !publicIds.Any())
+            throw new BadRequestException("No public IDs provided.");
+
+
+        await _cloudinary.DeleteMultipleAsync(publicIds);
+
+
+        var images = await _unitOfWork.ProductImages
+            .GetByPublicIdsAsync(publicIds);
+
+        if (images.Any())
+        {
+            _unitOfWork.ProductImages.RemoveRange(images);
+            await _unitOfWork.SaveChangesAsync();
+        }
+    }
+
+
 }

--- a/src/backend/ReUse.Application/Services/ProductService.cs
+++ b/src/backend/ReUse.Application/Services/ProductService.cs
@@ -1,0 +1,327 @@
+﻿using Microsoft.AspNetCore.Http;
+
+using ReUse.Application.DTOs.Products;
+using ReUse.Application.DTOs.Products.Requests;
+using ReUse.Application.DTOs.Products.Responses;
+using ReUse.Application.Exceptions;
+using ReUse.Application.Interfaces;
+using ReUse.Application.Interfaces.Services;
+using ReUse.Domain.Entities;
+using ReUse.Domain.Enums;
+
+namespace ReUse.Application.Services;
+
+public class ProductService : IProductService
+{
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IProductImageService _productImageService;
+
+    public ProductService(IUnitOfWork unitOfWork, IProductImageService productImageService)
+    {
+        _unitOfWork = unitOfWork;
+        _productImageService = productImageService;
+    }
+
+    // REGULAR 
+    public async Task<ProductResponse> CreateRegularProductAsync(
+        CreateRegularProductRequest request,
+        Guid sellerId)
+    {
+        if (request is null)
+            throw new BadRequestException("Request cannot be null");
+
+        if (request.BasicInfo is null)
+            throw new BadRequestException("Invalid basic info");
+
+        await EnsureLeafCategory(request.BasicInfo.CategoryId);
+
+        var product = new RegularProduct
+        {
+            Title = request.BasicInfo.Title,
+            Description = request.BasicInfo.Description,
+            CategoryId = request.BasicInfo.CategoryId,
+            Condition = request.BasicInfo.Condition,
+            OwnerUserId = sellerId,
+            Price = request.Price,
+            AllowNegotiation = request.AllowNegotiation
+        };
+
+        return await PersistProductAsync(product, request.Images);
+    }
+
+    // SWAP 
+    public async Task<ProductResponse> CreateSwapProductAsync(
+        CreateSwapProductRequest request,
+        Guid sellerId)
+    {
+        if (request is null)
+            throw new BadRequestException("Request cannot be null");
+
+        if (request.BasicInfo is null)
+            throw new BadRequestException("Invalid basic info");
+
+        if (request.OfferImages is null || !request.OfferImages.Any())
+            throw new BadRequestException("Offer images are required");
+
+        await EnsureLeafCategory(request.BasicInfo.CategoryId);
+
+        var product = new SwapProduct
+        {
+            Title = request.BasicInfo.Title,
+            Description = request.BasicInfo.Description,
+            CategoryId = request.BasicInfo.CategoryId,
+            Condition = request.BasicInfo.Condition,
+            OwnerUserId = sellerId,
+            WantedItemTitle = request.WantedItemTitle,
+            WantedItemDescription = request.WantedItemDescription
+        };
+
+        return await PersistSwapProductAsync(
+            product,
+            request.OfferImages,
+            request.WantedImages
+        );
+    }
+
+    private async Task<ProductResponse> PersistSwapProductAsync(
+        SwapProduct product,
+        List<IFormFile> offerImages,
+        List<IFormFile>? wantedImages)
+    {
+        List<string>? uploadedIds = null;
+
+        await _unitOfWork.BeginTransactionAsync();
+
+        try
+        {
+            _unitOfWork.Product.Add(product);
+            await _unitOfWork.SaveChangesAsync();
+
+            var allUploaded = new List<UploadedImageResponse>();
+
+            int offerCount = offerImages?.Count ?? 0;
+
+            // Offer
+            if (offerImages?.Any() == true)
+            {
+                var offerUpload = await _productImageService.UploadMultipleImagesAsync(
+                    new UploadProductImagesRequest
+                    {
+                        Id = product.Id,
+                        Images = offerImages
+                    });
+
+                allUploaded.AddRange(offerUpload);
+            }
+
+            // Wanted
+            if (wantedImages?.Any() == true)
+            {
+                var wantedUpload = await _productImageService.UploadMultipleImagesAsync(
+                    new UploadProductImagesRequest
+                    {
+                        Id = product.Id,
+                        Images = wantedImages
+                    });
+
+                allUploaded.AddRange(wantedUpload);
+            }
+
+            uploadedIds = allUploaded.Select(x => x.PublicId).ToList();
+
+            await _unitOfWork.CommitTransactionAsync();
+
+            var fullProduct = await _unitOfWork.Product.GetByIdAsync(product.Id) ?? product;
+
+            return MapSwapProduct((SwapProduct)fullProduct, offerCount);
+        }
+        catch
+        {
+            await _unitOfWork.RollbackTransactionAsync();
+
+            if (uploadedIds?.Any() == true)
+                await _productImageService.DeleteByPublicIdsAsync(uploadedIds);
+
+            throw;
+        }
+    }
+
+    //  WANTED 
+    public async Task<ProductResponse> CreateWantedProductAsync(
+        CreateWantedProductRequest request,
+        Guid sellerId)
+    {
+        if (request is null)
+            throw new BadRequestException("Request cannot be null");
+
+        if (request.BasicInfo is null)
+            throw new BadRequestException("Invalid basic info");
+
+        await EnsureLeafCategory(request.BasicInfo.CategoryId);
+
+        var product = new WantedProduct
+        {
+            Title = request.BasicInfo.Title,
+            Description = request.BasicInfo.Description,
+            CategoryId = request.BasicInfo.CategoryId,
+            Condition = request.BasicInfo.Condition,
+            OwnerUserId = sellerId,
+            DesiredPriceMin = request.DesiredPriceMin,
+            DesiredPriceMax = request.DesiredPriceMax
+        };
+
+        return await PersistProductAsync(product, request.Images);
+    }
+
+    // COMMON 
+    private async Task<ProductResponse> PersistProductAsync(
+        Product product,
+        List<IFormFile> imageFiles)
+    {
+        List<string>? uploadedPublicIds = null;
+
+        await _unitOfWork.BeginTransactionAsync();
+
+        try
+        {
+            _unitOfWork.Product.Add(product);
+            await _unitOfWork.SaveChangesAsync();
+
+            if (imageFiles?.Any() == true)
+            {
+                var uploadedImages = await _productImageService
+                    .UploadMultipleImagesAsync(new UploadProductImagesRequest
+                    {
+                        Id = product.Id,
+                        Images = imageFiles
+                    });
+
+                uploadedPublicIds = uploadedImages.Select(x => x.PublicId).ToList();
+            }
+
+            await _unitOfWork.CommitTransactionAsync();
+
+            var fullProduct = await _unitOfWork.Product
+                .GetByIdAsync(product.Id) ?? product;
+
+            return fullProduct.ProductType switch
+            {
+                ProductType.Regular => MapRegularProduct((RegularProduct)fullProduct),
+                ProductType.Swap => MapSwapProduct((SwapProduct)fullProduct, 0), // fallback
+                ProductType.Wanted => MapWantedProduct((WantedProduct)fullProduct),
+                _ => throw new InvalidOperationException("Unknown product type")
+            };
+        }
+        catch
+        {
+            await _unitOfWork.RollbackTransactionAsync();
+
+            if (uploadedPublicIds?.Any() == true)
+                await _productImageService.DeleteByPublicIdsAsync(uploadedPublicIds);
+
+            throw;
+        }
+    }
+
+    private async Task EnsureLeafCategory(Guid categoryId)
+    {
+        var category = await _unitOfWork.Category.GetByIdAsync(categoryId);
+
+        if (category is null)
+            throw new NotFoundException("Category not found");
+
+        if (category.ParentId is null)
+            throw new BadRequestException("Category must be a subcategory");
+    }
+
+    // MAPPING 
+
+    private ProductResponse MapRegularProduct(RegularProduct product)
+    {
+        var images = MapImages(product);
+
+        return new ProductResponse(
+            product.Id,
+            product.ProductType,
+            product.Title,
+            product.Description,
+            product.CategoryId,
+            product.Condition,
+            product.OwnerUserId,
+            product.CreatedAt,
+            product.Price,
+            product.AllowNegotiation,
+            null,
+            null,
+            null,
+            null,
+            images,
+            images.FirstOrDefault()?.Url ?? string.Empty
+        );
+    }
+
+    private ProductResponse MapWantedProduct(WantedProduct product)
+    {
+        var images = MapImages(product);
+
+        return new ProductResponse(
+            product.Id,
+            product.ProductType,
+            product.Title,
+            product.Description,
+            product.CategoryId,
+            product.Condition,
+            product.OwnerUserId,
+            product.CreatedAt,
+            null,
+            false,
+            null,
+            null,
+            product.DesiredPriceMin,
+            product.DesiredPriceMax,
+            images,
+            images.FirstOrDefault()?.Url ?? string.Empty
+        );
+    }
+
+    private ProductResponse MapSwapProduct(SwapProduct product, int offerCount)
+    {
+        var images = product.ProductImages ?? new List<ProductImage>();
+
+        var offerImages = images.Take(offerCount)
+            .Select(i => new UploadedImageResponse(i.Id, i.Url, i.PublicId))
+            .ToList();
+
+        var wantedImages = images.Skip(offerCount)
+            .Select(i => new UploadedImageResponse(i.Id, i.Url, i.PublicId))
+            .ToList();
+
+        var allImages = offerImages.Concat(wantedImages).ToList();
+
+        return new ProductResponse(
+            product.Id,
+            product.ProductType,
+            product.Title,
+            product.Description,
+            product.CategoryId,
+            product.Condition,
+            product.OwnerUserId,
+            product.CreatedAt,
+            null,
+            false,
+            product.WantedItemTitle,
+            product.WantedItemDescription,
+            null,
+            null,
+            allImages,
+            offerImages.FirstOrDefault()?.Url ?? string.Empty
+        );
+    }
+
+    private List<UploadedImageResponse> MapImages(Product product)
+    {
+        return product.ProductImages?
+            .Select(i => new UploadedImageResponse(i.Id, i.Url, i.PublicId))
+            .ToList() ?? new List<UploadedImageResponse>();
+    }
+}

--- a/src/backend/ReUse.Domain/Entities/ProductImage.cs
+++ b/src/backend/ReUse.Domain/Entities/ProductImage.cs
@@ -4,12 +4,15 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+using ReUse.Domain.Enums;
+
 namespace ReUse.Domain.Entities;
 
 public class ProductImage : BaseEntity
 {
     public string Url { get; set; } = null!;
     public int DisplayOrder { get; set; }
+    public ProductImageType Type { get; set; }
     //public bool IsPrimary { get; set; } // not needed since we can determine the primary image by the display order (the one with the lowest display order is the primary image)
     // cloudinary public id for deletion
     public string PublicId { get; set; } = null!;

--- a/src/backend/ReUse.Domain/Enums/ProductImageType.cs
+++ b/src/backend/ReUse.Domain/Enums/ProductImageType.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReUse.Domain.Enums;
+
+public enum ProductImageType
+{
+    Offer,
+    Wanted
+}

--- a/src/backend/ReUse.Infrastructure/DependencyInjection.cs
+++ b/src/backend/ReUse.Infrastructure/DependencyInjection.cs
@@ -66,6 +66,7 @@ public static class DependencyInjection
         ProductImageRepository>();
         services.AddScoped<ICategoryRepository,
         CategoryRepository>();
+        services.AddScoped<IProductRepository, ProductRepository>();
         #endregion
 
         #region Services

--- a/src/backend/ReUse.Infrastructure/Persistence/Migrations/20260502213625_AddImageTypeToProductImage.Designer.cs
+++ b/src/backend/ReUse.Infrastructure/Persistence/Migrations/20260502213625_AddImageTypeToProductImage.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ReUse.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using ReUse.Infrastructure.Persistence;
 namespace ReUse.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260502213625_AddImageTypeToProductImage")]
+    partial class AddImageTypeToProductImage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/backend/ReUse.Infrastructure/Persistence/Migrations/20260502213625_AddImageTypeToProductImage.cs
+++ b/src/backend/ReUse.Infrastructure/Persistence/Migrations/20260502213625_AddImageTypeToProductImage.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ReUse.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImageTypeToProductImage : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Type",
+                table: "ProductImages",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Type",
+                table: "ProductImages");
+        }
+    }
+}

--- a/src/backend/ReUse.Infrastructure/Repositories/BaseRepository.cs
+++ b/src/backend/ReUse.Infrastructure/Repositories/BaseRepository.cs
@@ -48,5 +48,10 @@ public class BaseRepository<T> : IBaseRepository<T> where T : class
         await _dbSet.AddRangeAsync(entities);
     }
 
+    public void RemoveRange(IEnumerable<T> entities)
+    {
+        _dbSet.RemoveRange(entities);
+    }
+
 
 }

--- a/src/backend/ReUse.Infrastructure/Repositories/ProductImageRepository.cs
+++ b/src/backend/ReUse.Infrastructure/Repositories/ProductImageRepository.cs
@@ -27,4 +27,14 @@ public class ProductImageRepository : BaseRepository<ProductImage>, IProductImag
         return await _context.ProductImages
             .CountAsync(x => x.ProductId == productId);
     }
+
+    public async Task<List<ProductImage>> GetByPublicIdsAsync(IEnumerable<string> publicIds)
+    {
+        if (publicIds is null || !publicIds.Any())
+            return new List<ProductImage>();
+
+        return await _context.ProductImages
+            .Where(x => publicIds.Contains(x.PublicId))
+            .ToListAsync();
+    }
 }

--- a/src/backend/ReUse.Infrastructure/Repositories/ProductRepository.cs
+++ b/src/backend/ReUse.Infrastructure/Repositories/ProductRepository.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using ReUse.Application.Interfaces.Repository;
+using ReUse.Domain.Entities;
+using ReUse.Infrastructure.Persistence;
+
+namespace ReUse.Infrastructure.Repositories;
+
+public class ProductRepository : BaseRepository<Product>, IProductRepository
+{
+    private readonly ApplicationDbContext _context;
+    public ProductRepository(ApplicationDbContext context) : base(context)
+    {
+        _context = context;
+    }
+}

--- a/src/backend/ReUse.Infrastructure/Services/Storage/CloudinaryService.cs
+++ b/src/backend/ReUse.Infrastructure/Services/Storage/CloudinaryService.cs
@@ -69,4 +69,21 @@ public class CloudinaryService : ICloudinaryService
         });
     }
     #endregion
+
+    #region DeleteMultiple
+    public async Task DeleteMultipleAsync(IEnumerable<string> publicIds)
+    {
+        if (publicIds is null || !publicIds.Any())
+            return;
+
+        var deleteTasks = publicIds
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => _cloudinary.DestroyAsync(new DeletionParams(id)
+            {
+                ResourceType = ResourceType.Image
+            }));
+
+        await Task.WhenAll(deleteTasks);
+    }
+    #endregion
 }

--- a/src/backend/ReUse.Infrastructure/UnitOfWork/UnitOfWork.cs
+++ b/src/backend/ReUse.Infrastructure/UnitOfWork/UnitOfWork.cs
@@ -1,4 +1,6 @@
 
+using Microsoft.EntityFrameworkCore.Storage;
+
 using ReUse.Application.Interfaces;
 using ReUse.Application.Interfaces.Repository;
 using ReUse.Infrastructure.Persistence;
@@ -9,6 +11,7 @@ namespace ReUse.Infrastructure.UnitOfWork;
 public class UnitOfWork : IUnitOfWork
 {
     private readonly ApplicationDbContext _context;
+    private IDbContextTransaction? _transaction;
     public UnitOfWork(ApplicationDbContext context)
     {
         _context = context;
@@ -16,17 +19,41 @@ public class UnitOfWork : IUnitOfWork
         Follow = new FollowRepository(_context);
         Category = new CategoryRepository(_context);
         ProductImages = new ProductImageRepository(_context);
+        Product = new ProductRepository(_context);
     }
     public IUserRepository User { get; private set; }
 
     public IFollowRepository Follow { get; private set; }
     public IProductImageRepository ProductImages { get; private set; }
+
+    public IProductRepository Product { get; private set; }
     public ICategoryRepository Category { get; private set; }
 
+    public async Task CommitTransactionAsync()
+    {
+        if (_transaction is null) return;
+
+        await _transaction.CommitAsync();
+        await _transaction.DisposeAsync();
+
+        _transaction = null;
+    }
+
+    public async Task BeginTransactionAsync()
+    {
+        _transaction = await _context.Database.BeginTransactionAsync();
+    }
+    public async Task RollbackTransactionAsync()
+    {
+        if (_transaction is null) return;
+
+        await _transaction.RollbackAsync();
+        await _transaction.DisposeAsync();
+        _transaction = null;
+    }
     public async Task<int> SaveChangesAsync()
     {
         return await _context.SaveChangesAsync();
-        ProductImages = new ProductImageRepository(_context);
 
     }
 


### PR DESCRIPTION
in swap Product I'm make an two image[] one for offer Item , and one for Wanted item 
and in ProductImage Entity add enum of imagetype 

I'm testing all endpoints in this edgs 
Swap
OfferImages = null (Wrong)
OfferImages > 10  (Wrong)
WantedImages > 10 (Wrong)
Empty WantedImages  (valid)

Regular
Images = null (Wrong)
Images = empty (Wrong)
Images > 10 (Wrong)

Invalid Wanted (max < min)

Category
CategoryId = Parent (Wrong)
CategoryId = subcatigory (valid)

if You see Any More  talk me  ,
Notes
This version Use Manual Mapping ..
I Have one response for all three Endpoint With nullable fildes >> to support GetAll optimization
Now Uploading apply after save product in db to catch productid ..