### PR TITLE
Add user, category, and product seeders with sample data

### DIFF
--- a/src/backend/ReUse.API/Extensions/AppExtensions.cs
+++ b/src/backend/ReUse.API/Extensions/AppExtensions.cs
@@ -29,6 +29,9 @@ public static class AppExtensions
 
         RoleSeeder.SeedRolesAsync(services).GetAwaiter().GetResult();
         IdentitySeeder.SeedAdminAsync(services).GetAwaiter().GetResult();
+        UserSeeder.SeedAsync(services).GetAwaiter().GetResult();
+        CategorySeeder.SeedAsync(services).GetAwaiter().GetResult();
+        ProductSeeder.SeedAsync(services).GetAwaiter().GetResult();
     }
 
     public static void UseSwaggerServices(this WebApplication app)

--- a/src/backend/ReUse.Infrastructure/Seeders/CategorySeeder.cs
+++ b/src/backend/ReUse.Infrastructure/Seeders/CategorySeeder.cs
@@ -1,0 +1,238 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using ReUse.Domain.Entities;
+using ReUse.Infrastructure.Persistence;
+
+namespace ReUse.Infrastructure.Seeders;
+
+public static class CategorySeeder
+{
+    private record SeedCategory(
+        string Name,
+        string Slug,
+        string Description,
+        string IconUrl,
+        SeedCategory[] Children);
+
+    private static readonly SeedCategory[] Tree =
+    {
+        new(
+            "Electronics",
+            "electronics",
+            "Phones, laptops, cameras and other consumer electronics.",
+            "https://images.unsplash.com/photo-1498049794561-7780e7231661?w=400",
+            new SeedCategory[]
+            {
+                new("Phones & Accessories", "phones-accessories", "Smartphones, cases, chargers and accessories.",
+                    "https://images.unsplash.com/photo-1511707171634-5f897ff02aa9?w=400", Array.Empty<SeedCategory>()),
+                new("Laptops & Computers", "laptops-computers", "Laptops, desktops and computer hardware.",
+                    "https://images.unsplash.com/photo-1496181133206-80ce9b88a853?w=400", Array.Empty<SeedCategory>()),
+                new("Cameras", "cameras", "DSLR, mirrorless and point-and-shoot cameras.",
+                    "https://images.unsplash.com/photo-1502920917128-1aa500764cbd?w=400", Array.Empty<SeedCategory>()),
+                new("Audio", "audio", "Headphones, speakers and home audio gear.",
+                    "https://images.unsplash.com/photo-1505740420928-5e560c06d30e?w=400", Array.Empty<SeedCategory>()),
+                new("Gaming", "gaming", "Consoles, games and gaming accessories.",
+                    "https://images.unsplash.com/photo-1493711662062-fa541adb3fc8?w=400", Array.Empty<SeedCategory>()),
+            }),
+        new(
+            "Fashion - Men",
+            "fashion-men",
+            "Men's clothing, shoes and accessories.",
+            "https://images.unsplash.com/photo-1490578474895-699cd4e2cf59?w=400",
+            new SeedCategory[]
+            {
+                new("Shirts & T-Shirts", "men-shirts-tshirts", "Casual and formal shirts for men.",
+                    "https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?w=400", Array.Empty<SeedCategory>()),
+                new("Pants & Jeans", "men-pants-jeans", "Trousers, jeans and shorts.",
+                    "https://images.unsplash.com/photo-1542272604-787c3835535d?w=400", Array.Empty<SeedCategory>()),
+                new("Men's Shoes", "men-shoes", "Sneakers, formal shoes and boots.",
+                    "https://images.unsplash.com/photo-1542291026-7eec264c27ff?w=400", Array.Empty<SeedCategory>()),
+                new("Watches", "men-watches", "Mechanical, smart and dress watches.",
+                    "https://images.unsplash.com/photo-1524592094714-0f0654e20314?w=400", Array.Empty<SeedCategory>()),
+            }),
+        new(
+            "Fashion - Women",
+            "fashion-women",
+            "Women's clothing, shoes and accessories.",
+            "https://images.unsplash.com/photo-1483985988355-763728e1935b?w=400",
+            new SeedCategory[]
+            {
+                new("Dresses", "women-dresses", "Casual, evening and summer dresses.",
+                    "https://images.unsplash.com/photo-1595777457583-95e059d581b8?w=400", Array.Empty<SeedCategory>()),
+                new("Tops & Blouses", "women-tops", "Tops, blouses and shirts.",
+                    "https://images.unsplash.com/photo-1551488831-00ddcb6c6bd3?w=400", Array.Empty<SeedCategory>()),
+                new("Women's Shoes", "women-shoes", "Heels, flats, sneakers and boots.",
+                    "https://images.unsplash.com/photo-1543163521-1bf539c55dd2?w=400", Array.Empty<SeedCategory>()),
+                new("Bags", "women-bags", "Handbags, totes and clutches.",
+                    "https://images.unsplash.com/photo-1548036328-c9fa89d128fa?w=400", Array.Empty<SeedCategory>()),
+                new("Jewelry", "women-jewelry", "Rings, necklaces, earrings and bracelets.",
+                    "https://images.unsplash.com/photo-1515562141207-7a88fb7ce338?w=400", Array.Empty<SeedCategory>()),
+            }),
+        new(
+            "Home & Garden",
+            "home-garden",
+            "Furniture, decor and gardening supplies.",
+            "https://images.unsplash.com/photo-1484101403633-562f891dc89a?w=400",
+            new SeedCategory[]
+            {
+                new("Furniture", "furniture", "Sofas, tables, chairs and storage.",
+                    "https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=400", Array.Empty<SeedCategory>()),
+                new("Kitchen & Dining", "kitchen-dining", "Cookware, tableware and small appliances.",
+                    "https://images.unsplash.com/photo-1556909114-f6e7ad7d3136?w=400", Array.Empty<SeedCategory>()),
+                new("Decor", "decor", "Lamps, vases, frames and accents.",
+                    "https://images.unsplash.com/photo-1513519245088-0e12902e5a38?w=400", Array.Empty<SeedCategory>()),
+                new("Garden", "garden", "Plants, pots and outdoor tools.",
+                    "https://images.unsplash.com/photo-1416879595882-3373a0480b5b?w=400", Array.Empty<SeedCategory>()),
+            }),
+        new(
+            "Toys & Games",
+            "toys-games",
+            "Toys, board games and puzzles.",
+            "https://images.unsplash.com/photo-1558060370-d644479cb6f7?w=400",
+            new SeedCategory[]
+            {
+                new("Board Games", "board-games", "Strategy, family and party board games.",
+                    "https://images.unsplash.com/photo-1606503153255-59d8b8b1b2bf?w=400", Array.Empty<SeedCategory>()),
+                new("Action Figures", "action-figures", "Collectible figures and models.",
+                    "https://images.unsplash.com/photo-1608889335941-32ac5f2041b9?w=400", Array.Empty<SeedCategory>()),
+                new("LEGO & Building", "lego-building", "LEGO sets and other building toys.",
+                    "https://images.unsplash.com/photo-1587654780291-39c9404d746b?w=400", Array.Empty<SeedCategory>()),
+            }),
+        new(
+            "Books & Media",
+            "books-media",
+            "Books, music and films.",
+            "https://images.unsplash.com/photo-1512820790803-83ca734da794?w=400",
+            new SeedCategory[]
+            {
+                new("Books", "books", "Fiction, non-fiction and textbooks.",
+                    "https://images.unsplash.com/photo-1495446815901-a7297e633e8d?w=400", Array.Empty<SeedCategory>()),
+                new("Vinyl & CDs", "vinyl-cds", "Records, CDs and music memorabilia.",
+                    "https://images.unsplash.com/photo-1603048588665-791ca8aea617?w=400", Array.Empty<SeedCategory>()),
+                new("Movies", "movies", "DVDs, Blu-ray and movie collectibles.",
+                    "https://images.unsplash.com/photo-1489599849927-2ee91cede3ba?w=400", Array.Empty<SeedCategory>()),
+            }),
+        new(
+            "Sports & Outdoors",
+            "sports-outdoors",
+            "Sports gear and outdoor equipment.",
+            "https://images.unsplash.com/photo-1517649763962-0c623066013b?w=400",
+            new SeedCategory[]
+            {
+                new("Bicycles", "bicycles", "Road, mountain and city bikes.",
+                    "https://images.unsplash.com/photo-1532298229144-0ec0c57515c7?w=400", Array.Empty<SeedCategory>()),
+                new("Fitness Equipment", "fitness-equipment", "Weights, mats and home-gym gear.",
+                    "https://images.unsplash.com/photo-1517836357463-d25dfeac3438?w=400", Array.Empty<SeedCategory>()),
+                new("Camping & Hiking", "camping-hiking", "Tents, backpacks and outdoor tools.",
+                    "https://images.unsplash.com/photo-1504280390367-361c6d9f38f4?w=400", Array.Empty<SeedCategory>()),
+            }),
+        new(
+            "Vehicles",
+            "vehicles",
+            "Cars, motorcycles and vehicle parts.",
+            "https://images.unsplash.com/photo-1493238792000-8113da705763?w=400",
+            new SeedCategory[]
+            {
+                new("Cars", "cars", "Used cars and sedans.",
+                    "https://images.unsplash.com/photo-1494976388531-d1058494cdd8?w=400", Array.Empty<SeedCategory>()),
+                new("Motorcycles", "motorcycles", "Motorcycles and scooters.",
+                    "https://images.unsplash.com/photo-1568772585407-9361f9bf3a87?w=400", Array.Empty<SeedCategory>()),
+                new("Auto Parts", "auto-parts", "Spare parts and accessories.",
+                    "https://images.unsplash.com/photo-1486262715619-67b85e0b08d3?w=400", Array.Empty<SeedCategory>()),
+            }),
+        new(
+            "Baby & Kids",
+            "baby-kids",
+            "Clothes, toys and gear for babies and children.",
+            "https://images.unsplash.com/photo-1515488042361-ee00e0ddd4e4?w=400",
+            new SeedCategory[]
+            {
+                new("Strollers & Car Seats", "strollers-car-seats", "Strollers, car seats and travel gear.",
+                    "https://images.unsplash.com/photo-1492725764893-90b379c2b6e7?w=400", Array.Empty<SeedCategory>()),
+                new("Kids' Clothing", "kids-clothing", "Clothes for boys and girls.",
+                    "https://images.unsplash.com/photo-1518831959646-742c3a14ebf7?w=400", Array.Empty<SeedCategory>()),
+                new("Kids' Toys", "kids-toys", "Educational and play toys.",
+                    "https://images.unsplash.com/photo-1503376780353-7e6692767b70?w=400", Array.Empty<SeedCategory>()),
+            }),
+        new(
+            "Pets",
+            "pets",
+            "Pet supplies and accessories.",
+            "https://images.unsplash.com/photo-1450778869180-41d0601e046e?w=400",
+            new SeedCategory[]
+            {
+                new("Dog Supplies", "dog-supplies", "Leashes, beds, toys and more for dogs.",
+                    "https://images.unsplash.com/photo-1587300003388-59208cc962cb?w=400", Array.Empty<SeedCategory>()),
+                new("Cat Supplies", "cat-supplies", "Litter boxes, scratchers and toys for cats.",
+                    "https://images.unsplash.com/photo-1574144611937-0df059b5ef3e?w=400", Array.Empty<SeedCategory>()),
+                new("Aquariums", "aquariums", "Tanks, filters and aquatic accessories.",
+                    "https://images.unsplash.com/photo-1522069169874-c58ec4b76be5?w=400", Array.Empty<SeedCategory>()),
+            }),
+        new(
+            "Tools & DIY",
+            "tools-diy",
+            "Hand tools, power tools and DIY supplies.",
+            "https://images.unsplash.com/photo-1530124566582-a618bc2615dc?w=400",
+            new SeedCategory[]
+            {
+                new("Power Tools", "power-tools", "Drills, saws and grinders.",
+                    "https://images.unsplash.com/photo-1504148455328-c376907d081c?w=400", Array.Empty<SeedCategory>()),
+                new("Hand Tools", "hand-tools", "Hammers, screwdrivers and wrenches.",
+                    "https://images.unsplash.com/photo-1581147036324-c1c89c2c8b5c?w=400", Array.Empty<SeedCategory>()),
+            }),
+        new(
+            "Beauty & Health",
+            "beauty-health",
+            "Beauty products and personal-care items.",
+            "https://images.unsplash.com/photo-1606570109843-5c1ff8e7cc1a",
+            new SeedCategory[]
+            {
+                new("Skincare", "skincare", "Cleansers, moisturizers and serums.",
+                    "https://images.unsplash.com/photo-1556228720-195a672e8a03?w=400", Array.Empty<SeedCategory>()),
+                new("Makeup", "makeup", "Lipstick, foundation and palettes.",
+                    "https://images.unsplash.com/photo-1522335789203-aaa54c0bf218?w=400", Array.Empty<SeedCategory>()),
+                new("Fragrances", "fragrances", "Perfumes and colognes.",
+                    "https://images.unsplash.com/photo-1541643600914-78b084683601?w=400", Array.Empty<SeedCategory>()),
+            }),
+    };
+
+    public static async Task SeedAsync(IServiceProvider services)
+    {
+        var dbContext = services.GetRequiredService<ApplicationDbContext>();
+
+        if (await dbContext.Categories.AnyAsync())
+        {
+            return;
+        }
+
+        foreach (var top in Tree)
+        {
+            var parent = new Category
+            {
+                Name = top.Name,
+                Slug = top.Slug,
+                Description = top.Description,
+                IconUrl = top.IconUrl,
+                IsActive = true,
+            };
+
+            dbContext.Categories.Add(parent);
+
+            foreach (var child in top.Children)
+            {
+                dbContext.Categories.Add(new Category
+                {
+                    Name = child.Name,
+                    Slug = child.Slug,
+                    Description = child.Description,
+                    IconUrl = child.IconUrl,
+                    IsActive = true,
+                    ParentId = parent.Id,
+                });
+            }
+        }
+
+        await dbContext.SaveChangesAsync();
+    }
+}

--- a/src/backend/ReUse.Infrastructure/Seeders/ProductSeeder.cs
+++ b/src/backend/ReUse.Infrastructure/Seeders/ProductSeeder.cs
@@ -1,0 +1,408 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using ReUse.Domain.Entities;
+using ReUse.Domain.Enums;
+using ReUse.Infrastructure.Persistence;
+
+namespace ReUse.Infrastructure.Seeders;
+
+public static class ProductSeeder
+{
+    private record SeedImage(string Url);
+
+    private record SeedProductBase(
+        string CategorySlug,
+        string OwnerEmail,
+        string Title,
+        string Description,
+        ProductCondition Condition,
+        string City,
+        string Country,
+        SeedImage[] Images);
+
+    private record SeedRegular(SeedProductBase Base, decimal Price, bool AllowNegotiation);
+    private record SeedSwap(SeedProductBase Base, string WantedTitle, string? WantedDescription, ProductCondition? WantedCondition);
+    private record SeedWanted(SeedProductBase Base, decimal? PriceMin, decimal? PriceMax);
+
+    private const string AhmedEmail = "ahmed.hassan@reuse.dev";
+    private const string SarahEmail = "sarah.mahmoud@reuse.dev";
+    private const string OmarEmail = "omar.khaled@reuse.dev";
+
+    private static readonly SeedRegular[] RegularProducts =
+    {
+        new(new SeedProductBase(
+            "phones-accessories", AhmedEmail,
+            "iPhone 13 Pro 256GB - Graphite",
+            "Apple iPhone 13 Pro, 256GB, Graphite. Battery health 92%. Includes original box and cable. No scratches on screen, minor wear on the frame.",
+            ProductCondition.LikeNew, "Cairo", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1632661674596-df8be070a5c5?w=800"),
+                new SeedImage("https://images.unsplash.com/photo-1591337676887-a217a6970a8a?w=800"),
+            }),
+            899m, true),
+        new(new SeedProductBase(
+            "laptops-computers", AhmedEmail,
+            "MacBook Pro 14\" M1 Pro 16GB / 512GB",
+            "2021 MacBook Pro with M1 Pro chip, 16GB unified memory, 512GB SSD. Used for development. Excellent condition, comes with original 67W charger.",
+            ProductCondition.Used, "Cairo", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1517336714731-489689fd1ca8?w=800"),
+                new SeedImage("https://images.unsplash.com/photo-1611186871348-b1ce696e52c9?w=800"),
+            }),
+            1450m, false),
+        new(new SeedProductBase(
+            "audio", AhmedEmail,
+            "Sony WH-1000XM4 Wireless Headphones",
+            "Industry-leading noise-cancelling headphones. Black. Includes carrying case, 3.5mm cable and USB-C charging cable.",
+            ProductCondition.LikeNew, "Cairo", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1583394838336-acd977736f90?w=800"),
+                new SeedImage("https://images.unsplash.com/photo-1545127398-14699f92334b?w=800"),
+            }),
+            220m, true),
+        new(new SeedProductBase(
+            "cameras", AhmedEmail,
+            "Canon EOS 90D DSLR Body",
+            "Canon EOS 90D body only. ~12k shutter count. Comes with battery, charger and original strap. No lens included.",
+            ProductCondition.Used, "Cairo", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1502920917128-1aa500764cbd?w=800"),
+                new SeedImage("https://images.unsplash.com/photo-1606983340126-99ab4feaa64a?w=800"),
+            }),
+            780m, true),
+        new(new SeedProductBase(
+            "gaming", AhmedEmail,
+            "PlayStation 5 Disc Edition",
+            "PS5 console with one DualSense controller. All cables included. Light usage, kept in a smoke-free home.",
+            ProductCondition.LikeNew, "Cairo", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1606813907291-d86efa9b94db?w=800"),
+                new SeedImage("https://images.unsplash.com/photo-1605901309584-818e25960a8f?w=800"),
+            }),
+            520m, false),
+
+        new(new SeedProductBase(
+            "women-dresses", SarahEmail,
+            "Zara Floral Midi Dress - Size M",
+            "Floral print midi dress from Zara, size M. Worn twice. Perfect for spring and summer occasions.",
+            ProductCondition.LikeNew, "Alexandria", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1595777457583-95e059d581b8?w=800"),
+                new SeedImage("https://images.unsplash.com/photo-1539109136881-3be0616acf4b?w=800"),
+            }),
+            45m, true),
+        new(new SeedProductBase(
+            "women-bags", SarahEmail,
+            "Michael Kors Leather Tote Bag",
+            "Michael Kors saffiano leather tote in tan. Light scratches inside. Authentic, comes with dust bag.",
+            ProductCondition.Used, "Alexandria", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1548036328-c9fa89d128fa?w=800"),
+                new SeedImage("https://images.unsplash.com/photo-1584917865442-de89df76afd3?w=800"),
+            }),
+            180m, true),
+        new(new SeedProductBase(
+            "women-shoes", SarahEmail,
+            "Nike Air Force 1 - Women's Size 38",
+            "Classic white Nike Air Force 1, women's EU 38. Worn a few times, original box included.",
+            ProductCondition.LikeNew, "Alexandria", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1595950653106-6c9ebd614d3a?w=800"),
+                new SeedImage("https://images.unsplash.com/photo-1542291026-7eec264c27ff?w=800"),
+            }),
+            85m, false),
+        new(new SeedProductBase(
+            "women-jewelry", SarahEmail,
+            "Pandora Sterling Silver Charm Bracelet",
+            "Authentic Pandora sterling silver bracelet with 5 charms. Comes with original pouch and certificate.",
+            ProductCondition.Used, "Alexandria", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1515562141207-7a88fb7ce338?w=800"),
+            }),
+            120m, true),
+        new(new SeedProductBase(
+            "women-tops", SarahEmail,
+            "H&M Linen Blouse - Size S",
+            "White linen blouse from H&M, size S. Brand new with tags.",
+            ProductCondition.New, "Alexandria", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1551488831-00ddcb6c6bd3?w=800"),
+            }),
+            22m, false),
+
+        new(new SeedProductBase(
+            "furniture", OmarEmail,
+            "IKEA MALM Desk - White, 140x65 cm",
+            "IKEA MALM desk in white, 140x65 cm. Lightly used, no major scratches. Disassembled for easy transport.",
+            ProductCondition.Used, "Giza", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1518455027359-f3f8164ba6bd?w=800"),
+                new SeedImage("https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=800"),
+            }),
+            95m, true),
+        new(new SeedProductBase(
+            "power-tools", OmarEmail,
+            "Bosch GSB 13 RE Impact Drill",
+            "Bosch GSB 13 RE 600W impact drill. Used on a couple of home projects. Comes with carrying case and bits.",
+            ProductCondition.Used, "Giza", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1504148455328-c376907d081c?w=800"),
+            }),
+            65m, true),
+        new(new SeedProductBase(
+            "hand-tools", OmarEmail,
+            "Stanley 65-piece Tool Kit",
+            "Complete Stanley 65-piece home tool set. Used a few times. All pieces present, original case.",
+            ProductCondition.LikeNew, "Giza", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1581147036324-c1c89c2c8b5c?w=800"),
+            }),
+            55m, false),
+        new(new SeedProductBase(
+            "decor", OmarEmail,
+            "Vintage Brass Table Lamp",
+            "Vintage brass table lamp, fully working. Adds a warm tone to any room. Bulb included.",
+            ProductCondition.Used, "Giza", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1513519245088-0e12902e5a38?w=800"),
+            }),
+            40m, true),
+        new(new SeedProductBase(
+            "kitchen-dining", OmarEmail,
+            "Le Creuset Cast Iron Dutch Oven 4.5L",
+            "Le Creuset enameled cast iron Dutch oven, 4.5L, cherry red. Light surface wear, fully functional.",
+            ProductCondition.Used, "Giza", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1556909114-f6e7ad7d3136?w=800"),
+            }),
+            150m, true),
+
+        new(new SeedProductBase(
+            "men-shoes", AhmedEmail,
+            "Adidas Ultraboost 22 - Size 43",
+            "Adidas Ultraboost 22 running shoes, EU 43. Used for casual wear, lots of life left.",
+            ProductCondition.Used, "Cairo", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1542291026-7eec264c27ff?w=800"),
+            }),
+            70m, true),
+        new(new SeedProductBase(
+            "men-watches", AhmedEmail,
+            "Seiko 5 Automatic SNK809",
+            "Seiko 5 automatic men's watch, black dial. Keeps great time. Original strap included.",
+            ProductCondition.Used, "Cairo", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1524592094714-0f0654e20314?w=800"),
+            }),
+            95m, false),
+        new(new SeedProductBase(
+            "books", SarahEmail,
+            "Atomic Habits by James Clear - Hardcover",
+            "Atomic Habits by James Clear, hardcover edition. Read once, like-new condition.",
+            ProductCondition.LikeNew, "Alexandria", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1495446815901-a7297e633e8d?w=800"),
+            }),
+            14m, false),
+        new(new SeedProductBase(
+            "bicycles", OmarEmail,
+            "Trek FX 3 Hybrid Bicycle - Size L",
+            "Trek FX 3 hybrid bike, size L (56 cm). Great for city commuting. Recently serviced.",
+            ProductCondition.Used, "Giza", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1532298229144-0ec0c57515c7?w=800"),
+            }),
+            420m, true),
+        new(new SeedProductBase(
+            "lego-building", AhmedEmail,
+            "LEGO Star Wars Millennium Falcon 75257",
+            "LEGO Star Wars Millennium Falcon set 75257. Built once, all pieces and instructions included.",
+            ProductCondition.LikeNew, "Cairo", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1587654780291-39c9404d746b?w=800"),
+            }),
+            130m, true),
+    };
+
+    private static readonly SeedSwap[] SwapProducts =
+    {
+        new(new SeedProductBase(
+            "gaming", AhmedEmail,
+            "Xbox Series S - Swap for Nintendo Switch OLED",
+            "Xbox Series S in mint condition with one controller. Looking to swap for a Nintendo Switch OLED in similar condition.",
+            ProductCondition.LikeNew, "Cairo", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1621259182978-fbf93132d53d?w=800"),
+            }),
+            "Nintendo Switch OLED", "White or neon edition preferred.", ProductCondition.LikeNew),
+        new(new SeedProductBase(
+            "women-bags", SarahEmail,
+            "Coach Crossbody Bag - Swap for Designer Wallet",
+            "Coach leather crossbody bag, brown. Looking to swap for a designer wallet (Coach, Michael Kors, Kate Spade).",
+            ProductCondition.Used, "Alexandria", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1584917865442-de89df76afd3?w=800"),
+            }),
+            "Designer Wallet", "Any condition or brand is welcome.", ProductCondition.LikeNew),
+        new(new SeedProductBase(
+            "bicycles", OmarEmail,
+            "Mountain Bike - Swap for Road Bike",
+            "Hardtail mountain bike, size M. Open to swapping for a road bike of similar value.",
+            ProductCondition.Used, "Giza", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1532298229144-0ec0c57515c7?w=800"),
+            }),
+            "Road Bike", "Aluminum or carbon frame, size M or L.", ProductCondition.Used),
+    };
+
+    private static readonly SeedWanted[] WantedProducts =
+    {
+        new(new SeedProductBase(
+            "phones-accessories", SarahEmail,
+            "Looking for: iPhone 14 or 15",
+            "Looking to buy a used iPhone 14 or 15, any color, 128GB or 256GB. Must be in good condition with no major scratches.",
+            ProductCondition.Used, "Alexandria", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1592750475338-74b7b21085ab?w=800"),
+            }),
+            700m, 1100m),
+        new(new SeedProductBase(
+            "furniture", AhmedEmail,
+            "Looking for: Office Chair (Ergonomic)",
+            "Looking for an ergonomic office chair, ideally Herman Miller, Steelcase or similar. Used is fine.",
+            ProductCondition.Used, "Cairo", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1580480055273-228ff5388ef8?w=800"),
+            }),
+            150m, 400m),
+        new(new SeedProductBase(
+            "books", OmarEmail,
+            "Looking for: Programming Books (C#, .NET)",
+            "Looking for any recent C#, .NET, or software-architecture books. Bundle deals welcome.",
+            ProductCondition.Used, "Giza", "Egypt",
+            new[]
+            {
+                new SeedImage("https://images.unsplash.com/photo-1532012197267-da84d127e765?w=800"),
+            }),
+            10m, 50m),
+    };
+
+    public static async Task SeedAsync(IServiceProvider services)
+    {
+        var dbContext = services.GetRequiredService<ApplicationDbContext>();
+
+        if (await dbContext.Products.AnyAsync())
+        {
+            return;
+        }
+
+        var categories = await dbContext.Categories
+            .ToDictionaryAsync(c => c.Slug, c => c.Id);
+
+        var users = await dbContext.Set<User>()
+            .ToDictionaryAsync(u => u.Email, u => u.Id);
+
+        foreach (var seed in RegularProducts)
+        {
+            var product = new RegularProduct
+            {
+                Title = seed.Base.Title,
+                Description = seed.Base.Description,
+                CategoryId = categories[seed.Base.CategorySlug],
+                OwnerUserId = users[seed.Base.OwnerEmail],
+                Condition = seed.Base.Condition,
+                LocationCity = seed.Base.City,
+                LocationCountry = seed.Base.Country,
+                Status = ProductStatus.Active,
+                Price = seed.Price,
+                AllowNegotiation = seed.AllowNegotiation,
+                ProductImages = BuildImages(seed.Base.Images, ProductImageType.Offer),
+            };
+            dbContext.Products.Add(product);
+        }
+
+        foreach (var seed in SwapProducts)
+        {
+            var product = new SwapProduct
+            {
+                Title = seed.Base.Title,
+                Description = seed.Base.Description,
+                CategoryId = categories[seed.Base.CategorySlug],
+                OwnerUserId = users[seed.Base.OwnerEmail],
+                Condition = seed.Base.Condition,
+                LocationCity = seed.Base.City,
+                LocationCountry = seed.Base.Country,
+                Status = ProductStatus.Active,
+                WantedItemTitle = seed.WantedTitle,
+                WantedItemDescription = seed.WantedDescription,
+                WantedCondition = seed.WantedCondition,
+                ProductImages = BuildImages(seed.Base.Images, ProductImageType.Offer),
+            };
+            dbContext.Products.Add(product);
+        }
+
+        foreach (var seed in WantedProducts)
+        {
+            var product = new WantedProduct
+            {
+                Title = seed.Base.Title,
+                Description = seed.Base.Description,
+                CategoryId = categories[seed.Base.CategorySlug],
+                OwnerUserId = users[seed.Base.OwnerEmail],
+                Condition = seed.Base.Condition,
+                LocationCity = seed.Base.City,
+                LocationCountry = seed.Base.Country,
+                Status = ProductStatus.Active,
+                DesiredPriceMin = seed.PriceMin,
+                DesiredPriceMax = seed.PriceMax,
+                ProductImages = BuildImages(seed.Base.Images, ProductImageType.Wanted),
+            };
+            dbContext.Products.Add(product);
+        }
+
+        await dbContext.SaveChangesAsync();
+    }
+
+    private static List<ProductImage> BuildImages(SeedImage[] images, ProductImageType type)
+    {
+        var list = new List<ProductImage>();
+        for (var i = 0; i < images.Length; i++)
+        {
+            var img = images[i];
+            list.Add(new ProductImage
+            {
+                Url = img.Url,
+                DisplayOrder = i,
+                Type = type,
+                PublicId = $"seed_{Guid.NewGuid():N}",
+            });
+        }
+        return list;
+    }
+}

--- a/src/backend/ReUse.Infrastructure/Seeders/UserSeeder.cs
+++ b/src/backend/ReUse.Infrastructure/Seeders/UserSeeder.cs
@@ -1,0 +1,106 @@
+using System.Security.Claims;
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Reuse.Infrastructure.Identity.Models;
+
+using ReUse.Domain.Entities;
+using ReUse.Infrastructure.Persistence;
+
+namespace ReUse.Infrastructure.Seeders;
+
+public static class UserSeeder
+{
+    private const string DefaultPassword = "User@123";
+    private const string UserRole = "User";
+
+    private record SeedUser(
+        string UserName,
+        string FullName,
+        string Email,
+        string Bio,
+        string City,
+        string Country);
+
+    private static readonly SeedUser[] Users =
+    {
+        new(
+            "ahmedhassan",
+            "Ahmed Hassan",
+            "ahmed.hassan@reuse.dev",
+            "Tech enthusiast giving gadgets a second life.",
+            "Cairo",
+            "Egypt"),
+        new(
+            "sarahmahmoud",
+            "Sarah Mahmoud",
+            "sarah.mahmoud@reuse.dev",
+            "Fashion lover passionate about sustainable wardrobes.",
+            "Alexandria",
+            "Egypt"),
+        new(
+            "omarkhaled",
+            "Omar Khaled",
+            "omar.khaled@reuse.dev",
+            "DIY builder and home-improvement hobbyist.",
+            "Giza",
+            "Egypt"),
+    };
+
+    public static async Task SeedAsync(IServiceProvider services)
+    {
+        var userManager = services.GetRequiredService<UserManager<ApplicationUser>>();
+        var dbContext = services.GetRequiredService<ApplicationDbContext>();
+
+        foreach (var seed in Users)
+        {
+            var identityUser = await userManager.FindByEmailAsync(seed.Email);
+            if (identityUser == null)
+            {
+                identityUser = new ApplicationUser
+                {
+                    UserName = seed.UserName,
+                    Email = seed.Email,
+                    EmailConfirmed = true
+                };
+
+                var result = await userManager.CreateAsync(identityUser, DefaultPassword);
+                if (!result.Succeeded)
+                {
+                    throw new Exception(string.Join(", ", result.Errors.Select(e => e.Description)));
+                }
+            }
+
+            if (!await userManager.IsInRoleAsync(identityUser, UserRole))
+            {
+                await userManager.AddToRoleAsync(identityUser, UserRole);
+            }
+
+            var domainUserExists = await dbContext.Set<User>()
+                .AnyAsync(u => u.IdentityUserId == identityUser.Id);
+
+            if (!domainUserExists)
+            {
+                var domainUser = new User
+                {
+                    IdentityUserId = identityUser.Id,
+                    Email = seed.Email,
+                    FullName = seed.FullName,
+                    Bio = seed.Bio,
+                    City = seed.City,
+                    Country = seed.Country,
+                };
+
+                dbContext.Add(domainUser);
+                await dbContext.SaveChangesAsync();
+
+                await userManager.AddClaimAsync(identityUser, new Claim(
+                    "business_user_id",
+                    domainUser.Id.ToString()
+                ));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds three seeders:
- UserSeeder seeds 3 regular users
- CategorySeeder seeds some top-level categories with some subcategories
- ProductSeeder seeds some products (Regular/Swap/Wanted)