### PR TITLE
 use AutoMapper for product DTO mappings

### DIFF
--- a/src/backend/ReUse.API/Controllers/ProductController.cs
+++ b/src/backend/ReUse.API/Controllers/ProductController.cs
@@ -28,7 +28,7 @@ public class ProductController : ControllerBase
     {
         var sellerId = User.GetBusinessId();
         var result = await _productService.CreateRegularProductAsync(request, sellerId);
-        return Ok(result);
+        return CreatedAtAction(nameof(GetById), new { productId = result.Id }, result);
 
     }
 
@@ -41,7 +41,7 @@ public class ProductController : ControllerBase
 
         var result = await _productService.CreateSwapProductAsync(request, sellerId);
 
-        return Ok(result);
+        return CreatedAtAction(nameof(GetById), new { productId = result.Id }, result);
     }
 
     [HttpPost("wanted")]
@@ -53,7 +53,7 @@ public class ProductController : ControllerBase
 
         var result = await _productService.CreateWantedProductAsync(request, sellerId);
 
-        return Ok(result);
+        return CreatedAtAction(nameof(GetById), new { productId = result.Id }, result);
     }
 
     [HttpGet("{productId:guid}")]
@@ -79,8 +79,8 @@ public class ProductController : ControllerBase
     [FromBody] UpdateRegularProductRequest request)
     {
         var userId = User.GetBusinessId();
-        var result = await _productService.UpdateRegularProductAsync(id, request, userId);
-        return Ok(result);
+        await _productService.UpdateRegularProductAsync(id, request, userId);
+        return NoContent();
     }
 
     [HttpPatch("swap/{id:guid}")]
@@ -89,8 +89,8 @@ public class ProductController : ControllerBase
         [FromBody] UpdateSwapProductRequest request)
     {
         var userId = User.GetBusinessId();
-        var result = await _productService.UpdateSwapProductAsync(id, request, userId);
-        return Ok(result);
+        await _productService.UpdateSwapProductAsync(id, request, userId);
+        return NoContent();
     }
 
     [HttpPatch("wanted/{id:guid}")]
@@ -99,8 +99,8 @@ public class ProductController : ControllerBase
         [FromBody] UpdateWantedProductRequest request)
     {
         var userId = User.GetBusinessId();
-        var result = await _productService.UpdateWantedProductAsync(id, request, userId);
-        return Ok(result);
+        await _productService.UpdateWantedProductAsync(id, request, userId);
+        return NoContent();
     }
 
 

--- a/src/backend/ReUse.Application/DTOs/Products/Responses/ProductDetailsResponse.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Responses/ProductDetailsResponse.cs
@@ -1,36 +1,34 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace ReUse.Application.DTOs.Products.Responses;
+﻿namespace ReUse.Application.DTOs.Products.Responses;
 
 public record ProductDetailsResponse
-(
-  Guid Id,
-  string Title,
-  string Description,
-  string Type,
-  string? Condition,
-  string Status,
-  string? LocationCity,
-    string? LocationCountry,
-// int Views,
-  decimal? Price,           //Rerular
-  bool? AllowNegotiation,  //Rerular
-  string WantedItemTitle, // Swap
-  string? WantedItemDescription,// Swap
-  string? WantedCondition,  // Swap
-  decimal? DesiredPriceMin, //Wanted
-  decimal? DesiredPriceMax, //Wanted
-  List<string> Images,
-  DateTime CreatedAt,
-  Guid CategoryId,
-  string CategoryName,
-  Guid OwnerUserId,
-  string OwnerUserName,
-  string MemberSince // => Owner.CreatedAt.ToString("MMMM yyyy")
-);
+{
+    public Guid Id { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
+    public string Type { get; init; } = string.Empty;
+    public string? Condition { get; init; }
+    public string Status { get; init; } = string.Empty;
+    public string? LocationCity { get; init; }
+    public string? LocationCountry { get; init; }
 
-// TODO : OwnerUserData (bool   Verified , double Rating , int TotalReviews , string ResponseRate , string ResponseTime )
+    // Regular
+    public decimal? Price { get; init; }
+    public bool? AllowNegotiation { get; init; }
+
+    // Swap
+    public string? WantedItemTitle { get; init; }
+    public string? WantedItemDescription { get; init; }
+    public string? WantedCondition { get; init; }
+
+    // Wanted
+    public decimal? DesiredPriceMin { get; init; }
+    public decimal? DesiredPriceMax { get; init; }
+
+    public List<string> Images { get; init; } = [];
+    public DateTime CreatedAt { get; init; }
+    public Guid CategoryId { get; init; }
+    public string CategoryName { get; init; } = string.Empty;
+    public Guid OwnerUserId { get; init; }
+    public string OwnerUserName { get; init; } = string.Empty;
+    public string MemberSince { get; init; } = string.Empty;
+}

--- a/src/backend/ReUse.Application/DTOs/Products/Responses/ProductResponse.cs
+++ b/src/backend/ReUse.Application/DTOs/Products/Responses/ProductResponse.cs
@@ -9,26 +9,26 @@ using ReUse.Domain.Enums;
 namespace ReUse.Application.DTOs.Products.Responses;
 
 public record ProductResponse
-    (
-      Guid Id,
-      ProductType Type,
-      string Title,
-      string Description,
-      Guid CategoryId,
-      ProductCondition? Condition,
-      string? LocationCity,
-      string? LocationCountry,
-      Guid OwnerUserId,
-      DateTime CreatedAt,
-      // Type-specific
-      decimal? Price, // Regular
-      bool AllowNegotiation, // Regular
-      string? WantedItem,   // Swap
-      string? WantedItemDescription,  // Swap
-      decimal? MinPrice,   // Wanted
-      decimal? MaxPrice,  // Wanted
+{
+    public Guid Id { get; init; }
+    public ProductType Type { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string Description { get; init; } = string.Empty;
+    public Guid CategoryId { get; init; }
+    public ProductCondition? Condition { get; init; }
+    public string? LocationCity { get; init; }
+    public string? LocationCountry { get; init; }
+    public Guid OwnerUserId { get; init; }
+    public DateTime CreatedAt { get; init; }
 
-      //  ShippingResponse? Shipping,
-      List<UploadedImageResponse> Images,
-      string CoverImageUrl
-    );
+    // Type-specific
+    public decimal? Price { get; init; }          // Regular
+    public bool AllowNegotiation { get; init; }   // Regular
+    public string? WantedItem { get; init; }      // Swap
+    public string? WantedItemDescription { get; init; } // Swap
+    public decimal? MinPrice { get; init; }       // Wanted
+    public decimal? MaxPrice { get; init; }       // Wanted
+
+    public List<UploadedImageResponse> Images { get; init; } = [];
+    public string CoverImageUrl { get; init; } = string.Empty;
+}

--- a/src/backend/ReUse.Application/Interfaces/Services/IProductService.cs
+++ b/src/backend/ReUse.Application/Interfaces/Services/IProductService.cs
@@ -19,9 +19,9 @@ public interface IProductService
     public Task<ProductResponse> CreateSwapProductAsync(CreateSwapProductRequest request, Guid sellerId);
     public Task<ProductResponse> CreateWantedProductAsync(CreateWantedProductRequest request, Guid sellerId);
 
-    Task<ProductResponse> UpdateRegularProductAsync(Guid productId, UpdateRegularProductRequest request, Guid userId);
-    Task<ProductResponse> UpdateSwapProductAsync(Guid productId, UpdateSwapProductRequest request, Guid userId);
-    Task<ProductResponse> UpdateWantedProductAsync(Guid productId, UpdateWantedProductRequest request, Guid userId);
+    Task UpdateRegularProductAsync(Guid productId, UpdateRegularProductRequest request, Guid userId);
+    Task UpdateSwapProductAsync(Guid productId, UpdateSwapProductRequest request, Guid userId);
+    Task UpdateWantedProductAsync(Guid productId, UpdateWantedProductRequest request, Guid userId);
 
 
     Task<ProductDetailsResponse> GetByIdAsync(Guid productId);

--- a/src/backend/ReUse.Application/Mappers/ConditionToStringConverter.cs
+++ b/src/backend/ReUse.Application/Mappers/ConditionToStringConverter.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using AutoMapper;
+
+using ReUse.Domain.Enums;
+
+namespace ReUse.Application.Mappers;
+
+public class ConditionToStringConverter
+    : ITypeConverter<ProductCondition?, string>
+{
+    public string Convert(
+        ProductCondition? source,
+        string destination,
+        ResolutionContext context)
+    {
+        return source switch
+        {
+            ProductCondition.New => "New",
+            ProductCondition.LikeNew => "Like New",
+            ProductCondition.Used => "Used",
+            ProductCondition.Broken => "Broken",
+            _ => source?.ToString() ?? "Unknown"
+        };
+    }
+}

--- a/src/backend/ReUse.Application/Mappers/ProductProfile.cs
+++ b/src/backend/ReUse.Application/Mappers/ProductProfile.cs
@@ -1,0 +1,200 @@
+﻿using AutoMapper;
+
+using ReUse.Application.DTOs.Products.Requests;
+using ReUse.Application.DTOs.Products.Responses;
+using ReUse.Domain.Entities;
+using ReUse.Domain.Enums;
+
+namespace ReUse.Application.Mappers;
+
+public class ProductProfile : Profile
+{
+    private static string? FormatCondition(ProductCondition? condition) => condition switch
+    {
+        ProductCondition.New => "New",
+        ProductCondition.LikeNew => "Like New",
+        ProductCondition.Used => "Used",
+        ProductCondition.Broken => "Broken",
+        null => null,
+        _ => condition.ToString()
+    };
+
+    public ProductProfile()
+    {
+        #region CreateRequests
+
+        CreateMap<BasicInfoRequest, Product>()
+              .ForMember(dest => dest.OwnerUserId, opt => opt.Ignore())
+              .ForMember(dest => dest.ProductImages, opt => opt.Ignore());
+
+        #region RegularProduct
+        CreateMap<BasicInfoRequest, RegularProduct>()
+            .IncludeBase<BasicInfoRequest, Product>();
+
+        CreateMap<CreateRegularProductRequest, RegularProduct>()
+            .IncludeMembers(src => src.BasicInfo);
+        #endregion
+
+        #region Wanted Product
+        CreateMap<BasicInfoRequest, WantedProduct>()
+            .IncludeBase<BasicInfoRequest, Product>();
+
+        CreateMap<CreateWantedProductRequest, WantedProduct>()
+            .IncludeMembers(src => src.BasicInfo);
+        #endregion
+
+        #region Swap Product
+        CreateMap<BasicInfoRequest, SwapProduct>()
+            .IncludeBase<BasicInfoRequest, Product>();
+
+        CreateMap<CreateSwapProductRequest, SwapProduct>()
+            .IncludeMembers(src => src.BasicInfo);
+        #endregion
+
+        #endregion
+
+        #region UpdateRequests
+
+        CreateMap<BasicInfoUpdateRequest, Product>()
+            .ForMember(dest => dest.Title, opt => opt.Condition(src => src.Title != null))
+            .ForMember(dest => dest.Description, opt => opt.Condition(src => src.Description != null))
+            .ForMember(dest => dest.LocationCity, opt => opt.Condition(src => src.LocationCity != null))
+            .ForMember(dest => dest.LocationCountry, opt => opt.Condition(src => src.LocationCountry != null))
+            .ForMember(dest => dest.CategoryId, opt => opt.Condition(src => src.CategoryId.HasValue))
+            .ForMember(dest => dest.Condition, opt => opt.Condition(src => src.Condition.HasValue))
+            .ForMember(dest => dest.ProductImages, opt => opt.Ignore())
+            .ForMember(dest => dest.OwnerUserId, opt => opt.Ignore());
+
+        #region Regular Update
+        CreateMap<BasicInfoUpdateRequest, RegularProduct>()
+            .IncludeBase<BasicInfoUpdateRequest, Product>();
+
+        CreateMap<UpdateRegularProductRequest, RegularProduct>()
+            .IncludeMembers(src => src.BasicInfo)
+            .ForMember(dest => dest.Price, opt => opt.Condition(src => src.Price.HasValue))
+            .ForMember(dest => dest.AllowNegotiation, opt => opt.Condition(src => src.AllowNegotiation.HasValue));
+        #endregion
+
+        #region Swap Update
+        CreateMap<BasicInfoUpdateRequest, SwapProduct>()
+            .IncludeBase<BasicInfoUpdateRequest, Product>();
+
+        CreateMap<UpdateSwapProductRequest, SwapProduct>()
+            .IncludeMembers(src => src.BasicInfo)
+            .ForMember(dest => dest.WantedItemTitle, opt => opt.Condition(src => src.WantedItemTitle != null))
+            .ForMember(dest => dest.WantedItemDescription, opt => opt.Condition(src => src.WantedItemDescription != null));
+        #endregion
+
+        #region Wanted Update
+        CreateMap<BasicInfoUpdateRequest, WantedProduct>()
+            .IncludeBase<BasicInfoUpdateRequest, Product>();
+
+        CreateMap<UpdateWantedProductRequest, WantedProduct>()
+            .IncludeMembers(src => src.BasicInfo)
+            .ForMember(dest => dest.DesiredPriceMin, opt => opt.Condition(src => src.DesiredPriceMin.HasValue))
+            .ForMember(dest => dest.DesiredPriceMax, opt => opt.Condition(src => src.DesiredPriceMax.HasValue));
+        #endregion
+
+        #endregion
+
+        #region Responses
+
+        #region ForGetById
+        CreateMap<Product, ProductDetailsResponse>()
+          .Include<RegularProduct, ProductDetailsResponse>()
+          .Include<SwapProduct, ProductDetailsResponse>()
+          .Include<WantedProduct, ProductDetailsResponse>()
+          .ForMember(dest => dest.Type,
+              opt => opt.MapFrom(src => src.ProductType.ToString()))
+          .ForMember(dest => dest.Condition,
+              opt => opt.MapFrom(src => FormatCondition(src.Condition)))
+          .ForMember(dest => dest.Status,
+              opt => opt.MapFrom(src => src.Status.ToString().ToLower()))
+          .ForMember(dest => dest.CategoryName,
+              opt => opt.MapFrom(src => src.Category.Name))
+          .ForMember(dest => dest.Images,
+              opt => opt.MapFrom(src =>
+                  src.ProductImages
+                     .OrderBy(i => i.DisplayOrder)
+                     .Select(i => i.Url)
+                     .ToList()))
+          .ForMember(dest => dest.OwnerUserName,
+              opt => opt.MapFrom(src => src.Owner.FullName))
+          .ForMember(dest => dest.MemberSince,
+              opt => opt.MapFrom(src => src.Owner.CreatedAt.ToString("MMMM yyyy")))
+          .ForMember(dest => dest.WantedCondition, opt => opt.Ignore());
+
+
+        // RegularProduct → ProductDetailsResponse
+        CreateMap<RegularProduct, ProductDetailsResponse>()
+            .IncludeBase<Product, ProductDetailsResponse>();
+
+        // SwapProduct → ProductDetailsResponse
+        CreateMap<SwapProduct, ProductDetailsResponse>()
+            .IncludeBase<Product, ProductDetailsResponse>()
+
+            .ForMember(dest => dest.WantedCondition,
+               opt => opt.MapFrom(src => FormatCondition(src.WantedCondition)));
+
+        // WantedProduct → ProductDetailsResponse
+        CreateMap<WantedProduct, ProductDetailsResponse>()
+            .IncludeBase<Product, ProductDetailsResponse>();
+
+        CreateMap<ProductCondition?, string>()
+            .ConvertUsing<ConditionToStringConverter>();
+        #endregion
+
+        #region ForGetAll
+
+        CreateMap<Product, ProductResponse>()
+            .Include<RegularProduct, ProductResponse>()
+            .Include<SwapProduct, ProductResponse>()
+            .Include<WantedProduct, ProductResponse>()
+            .ForMember(dest => dest.Type,
+                opt => opt.MapFrom(src => src.ProductType))
+            .ForMember(dest => dest.Images,
+                opt => opt.MapFrom(src =>
+                    src.ProductImages
+                       .OrderBy(i => i.DisplayOrder)
+                       .Select(i => new UploadedImageResponse(i.Id, i.Url, i.PublicId))
+                       .ToList()))
+            .ForMember(dest => dest.CoverImageUrl,
+                opt => opt.MapFrom(src =>
+                    src.ProductImages
+                       .OrderBy(i => i.DisplayOrder)
+                       .Select(i => i.Url)
+                       .FirstOrDefault() ?? string.Empty))
+            // Type-specific fields — ignore في الـ base
+            .ForMember(dest => dest.Price, opt => opt.Ignore())
+            .ForMember(dest => dest.AllowNegotiation, opt => opt.Ignore())
+            .ForMember(dest => dest.WantedItem, opt => opt.Ignore())
+            .ForMember(dest => dest.WantedItemDescription, opt => opt.Ignore())
+            .ForMember(dest => dest.MinPrice, opt => opt.Ignore())
+            .ForMember(dest => dest.MaxPrice, opt => opt.Ignore());
+
+        CreateMap<RegularProduct, ProductResponse>()
+            .IncludeBase<Product, ProductResponse>()
+            .ForMember(dest => dest.Price,
+                opt => opt.MapFrom(src => (decimal?)src.Price))
+            .ForMember(dest => dest.AllowNegotiation,
+                opt => opt.MapFrom(src => src.AllowNegotiation));
+
+        CreateMap<SwapProduct, ProductResponse>()
+            .IncludeBase<Product, ProductResponse>()
+            .ForMember(dest => dest.WantedItem,
+                opt => opt.MapFrom(src => src.WantedItemTitle))
+            .ForMember(dest => dest.WantedItemDescription,
+                opt => opt.MapFrom(src => src.WantedItemDescription));
+
+        CreateMap<WantedProduct, ProductResponse>()
+            .IncludeBase<Product, ProductResponse>()
+            .ForMember(dest => dest.MinPrice,
+                opt => opt.MapFrom(src => src.DesiredPriceMin))
+            .ForMember(dest => dest.MaxPrice,
+                opt => opt.MapFrom(src => src.DesiredPriceMax));
+
+        #endregion
+
+        #endregion
+    }
+}

--- a/src/backend/ReUse.Application/Services/ProductService.cs
+++ b/src/backend/ReUse.Application/Services/ProductService.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using AutoMapper;
+
+using Microsoft.AspNetCore.Http;
 
 using ReUse.Application.DTOs;
 using ReUse.Application.DTOs.Products;
@@ -16,11 +18,13 @@ public class ProductService : IProductService
 {
     private readonly IUnitOfWork _unitOfWork;
     private readonly IProductImageService _productImageService;
+    private readonly IMapper _mapper;
 
-    public ProductService(IUnitOfWork unitOfWork, IProductImageService productImageService)
+    public ProductService(IUnitOfWork unitOfWork, IProductImageService productImageService, IMapper mapper)
     {
         _unitOfWork = unitOfWork;
         _productImageService = productImageService;
+        _mapper = mapper;
     }
 
     #region Create
@@ -37,18 +41,8 @@ public class ProductService : IProductService
 
         await EnsureLeafCategory(request.BasicInfo.CategoryId);
 
-        var product = new RegularProduct
-        {
-            Title = request.BasicInfo.Title,
-            Description = request.BasicInfo.Description,
-            CategoryId = request.BasicInfo.CategoryId,
-            Condition = request.BasicInfo.Condition,
-            LocationCity = request.BasicInfo.LocationCity,
-            LocationCountry = request.BasicInfo.LocationCountry,
-            OwnerUserId = sellerId,
-            Price = request.Price,
-            AllowNegotiation = request.AllowNegotiation
-        };
+        var product = _mapper.Map<RegularProduct>(request);
+        product.OwnerUserId = sellerId;
 
         return await PersistProductAsync(product, request.Images);
     }
@@ -69,18 +63,8 @@ public class ProductService : IProductService
 
         await EnsureLeafCategory(request.BasicInfo.CategoryId);
 
-        var product = new SwapProduct
-        {
-            Title = request.BasicInfo.Title,
-            Description = request.BasicInfo.Description,
-            CategoryId = request.BasicInfo.CategoryId,
-            Condition = request.BasicInfo.Condition,
-            LocationCity = request.BasicInfo.LocationCity,
-            LocationCountry = request.BasicInfo.LocationCountry,
-            OwnerUserId = sellerId,
-            WantedItemTitle = request.WantedItemTitle,
-            WantedItemDescription = request.WantedItemDescription
-        };
+        var product = _mapper.Map<SwapProduct>(request);
+        product.OwnerUserId = sellerId;
 
         return await PersistSwapProductAsync(
             product,
@@ -101,18 +85,8 @@ public class ProductService : IProductService
 
         await EnsureLeafCategory(request.BasicInfo.CategoryId);
 
-        var product = new WantedProduct
-        {
-            Title = request.BasicInfo.Title,
-            Description = request.BasicInfo.Description,
-            CategoryId = request.BasicInfo.CategoryId,
-            Condition = request.BasicInfo.Condition,
-            LocationCity = request.BasicInfo.LocationCity,
-            LocationCountry = request.BasicInfo.LocationCountry,
-            OwnerUserId = sellerId,
-            DesiredPriceMin = request.DesiredPriceMin,
-            DesiredPriceMax = request.DesiredPriceMax
-        };
+        var product = _mapper.Map<WantedProduct>(request);
+        product.OwnerUserId = sellerId;
 
         return await PersistProductAsync(product, request.Images);
     }
@@ -128,21 +102,20 @@ public class ProductService : IProductService
         var product = await _unitOfWork.Product.GetProductDetailsAsync(productId);
 
         if (product is null)
-            throw new NotFoundException("Product not found.");
+            throw new NotFoundException("Product");
 
-        return MapToDetails(product);
+        return _mapper.Map<ProductDetailsResponse>(product);
     }
     #endregion
 
     #region GetAll
-    public async Task<PagedResult<ProductResponse>> GetAllProductsAsync(
-  ProductFilterParams filterParams)
+    public async Task<PagedResult<ProductResponse>> GetAllProductsAsync(ProductFilterParams filterParams)
     {
         var pagedProducts = await _unitOfWork.Product.GetAllAsync(filterParams);
 
         return new PagedResult<ProductResponse>
         {
-            Data = pagedProducts.Data.Select(MapToProductResponse).ToList(),
+            Data = pagedProducts.Data.Select(p => _mapper.Map<ProductResponse>(p)).ToList(),
             PageNumber = pagedProducts.PageNumber,
             PageSize = pagedProducts.PageSize,
             TotalRecords = pagedProducts.TotalRecords
@@ -152,13 +125,13 @@ public class ProductService : IProductService
 
     #region Update
 
-    public async Task<ProductResponse> UpdateRegularProductAsync(
+    public async Task UpdateRegularProductAsync(
         Guid productId,
         UpdateRegularProductRequest request,
         Guid userId)
     {
         var product = await _unitOfWork.Product.GetByIdAsync(productId)
-            ?? throw new NotFoundException("Product not found");
+            ?? throw new NotFoundException("Product");
 
         // Business Rules
         if (product.OwnerUserId != userId)
@@ -171,16 +144,7 @@ public class ProductService : IProductService
 
         var regular = (RegularProduct)product;
 
-        // Apply BasicInfo
-        if (request.BasicInfo is not null)
-            await ApplyBasicInfoUpdate(regular, request.BasicInfo);
-
-        // Apply type-specific fields
-        if (request.Price is not null)
-            regular.Price = request.Price.Value;
-
-        if (request.AllowNegotiation is not null)
-            regular.AllowNegotiation = request.AllowNegotiation.Value;
+        _mapper.Map(request, regular);
 
         // Post-update validation
         if (regular.Price <= 0)
@@ -188,16 +152,15 @@ public class ProductService : IProductService
 
         await _unitOfWork.SaveChangesAsync();
 
-        return MapRegularProduct(regular);
     }
 
-    public async Task<ProductResponse> UpdateSwapProductAsync(
+    public async Task UpdateSwapProductAsync(
         Guid productId,
         UpdateSwapProductRequest request,
         Guid userId)
     {
         var product = await _unitOfWork.Product.GetByIdAsync(productId)
-            ?? throw new NotFoundException("Product not found");
+            ?? throw new NotFoundException("Product");
 
         if (product.OwnerUserId != userId)
             throw new ForbiddenException("You don't own this product");
@@ -209,14 +172,7 @@ public class ProductService : IProductService
 
         var swap = (SwapProduct)product;
 
-        if (request.BasicInfo is not null)
-            await ApplyBasicInfoUpdate(swap, request.BasicInfo);
-
-        if (request.WantedItemTitle is not null)
-            swap.WantedItemTitle = request.WantedItemTitle;
-
-        if (request.WantedItemDescription is not null)
-            swap.WantedItemDescription = request.WantedItemDescription;
+        _mapper.Map(request, swap);
 
         // Post-update validation
         if (string.IsNullOrWhiteSpace(swap.WantedItemTitle))
@@ -224,16 +180,15 @@ public class ProductService : IProductService
 
         await _unitOfWork.SaveChangesAsync();
 
-        return MapSwapProduct(swap, 0);
     }
 
-    public async Task<ProductResponse> UpdateWantedProductAsync(
+    public async Task UpdateWantedProductAsync(
         Guid productId,
         UpdateWantedProductRequest request,
         Guid userId)
     {
         var product = await _unitOfWork.Product.GetByIdAsync(productId)
-            ?? throw new NotFoundException("Product not found");
+            ?? throw new NotFoundException("Product");
 
         if (product.OwnerUserId != userId)
             throw new ForbiddenException("You don't own this product");
@@ -245,14 +200,7 @@ public class ProductService : IProductService
 
         var wanted = (WantedProduct)product;
 
-        if (request.BasicInfo is not null)
-            await ApplyBasicInfoUpdate(wanted, request.BasicInfo);
-
-        if (request.DesiredPriceMin is not null)
-            wanted.DesiredPriceMin = request.DesiredPriceMin.Value;
-
-        if (request.DesiredPriceMax is not null)
-            wanted.DesiredPriceMax = request.DesiredPriceMax.Value;
+        _mapper.Map(request, wanted);
 
         // Post-update validation
         if (wanted.DesiredPriceMin.HasValue &&
@@ -261,33 +209,6 @@ public class ProductService : IProductService
             throw new BadRequestException("Maximum price must be >= minimum price after update");
 
         await _unitOfWork.SaveChangesAsync();
-
-        return MapWantedProduct(wanted);
-    }
-
-    // Helper Shared Method to Apply Basic Info Updates
-    private async Task ApplyBasicInfoUpdate(Product product, BasicInfoUpdateRequest info)
-    {
-        if (info.Title is not null)
-            product.Title = info.Title;
-
-        if (info.Description is not null)
-            product.Description = info.Description;
-
-        if (info.LocationCity is not null)
-            product.LocationCity = info.LocationCity;
-
-        if (info.LocationCountry is not null)
-            product.LocationCountry = info.LocationCountry;
-
-        if (info.CategoryId.HasValue)
-        {
-            await EnsureLeafCategory(info.CategoryId.Value);
-            product.CategoryId = info.CategoryId.Value;
-        }
-
-        if (info.Condition.HasValue)
-            product.Condition = info.Condition.Value;
     }
 
     #endregion
@@ -300,13 +221,9 @@ public class ProductService : IProductService
 
 
         var product = await _unitOfWork.Product.GetByIdAsync(productId)
-            ?? throw new NotFoundException("Product not found");
+            ?? throw new NotFoundException("Product");
 
         EnsureNotDeleted(product);
-
-        // already deleted
-        if (product.Status == ProductStatus.Deleted)
-            throw new NotFoundException("Product not found");
 
         product.Status = ProductStatus.Deleted;
 
@@ -318,7 +235,7 @@ public class ProductService : IProductService
     private static void EnsureNotDeleted(Product product)
     {
         if (product.Status == ProductStatus.Deleted)
-            throw new NotFoundException("Product not found");
+            throw new NotFoundException("Product");
     }
     #endregion
 
@@ -373,7 +290,7 @@ public class ProductService : IProductService
 
             var fullProduct = await _unitOfWork.Product.GetByIdAsync(product.Id) ?? product;
 
-            return MapSwapProduct((SwapProduct)fullProduct, offerCount);
+            return _mapper.Map<ProductResponse>(fullProduct);
         }
         catch
         {
@@ -419,13 +336,7 @@ public class ProductService : IProductService
             var fullProduct = await _unitOfWork.Product
                 .GetByIdAsync(product.Id) ?? product;
 
-            return fullProduct.ProductType switch
-            {
-                ProductType.Regular => MapRegularProduct((RegularProduct)fullProduct),
-                ProductType.Swap => MapSwapProduct((SwapProduct)fullProduct, 0), // fallback
-                ProductType.Wanted => MapWantedProduct((WantedProduct)fullProduct),
-                _ => throw new InvalidOperationException("Unknown product type")
-            };
+            return _mapper.Map<ProductResponse>(fullProduct);
         }
         catch
         {
@@ -443,7 +354,7 @@ public class ProductService : IProductService
         var category = await _unitOfWork.Category.GetByIdAsync(categoryId);
 
         if (category is null)
-            throw new NotFoundException("Category not found");
+            throw new NotFoundException("Category");
 
         if (category.ParentId is null)
             throw new BadRequestException("Category must be a subcategory");
@@ -451,236 +362,4 @@ public class ProductService : IProductService
 
     #endregion
 
-    #region MAPPING 
-
-    private static ProductResponse MapToProductResponse(Product product)
-    {
-        var images = product.ProductImages
-            .OrderBy(i => i.DisplayOrder)
-            .Select(i => new UploadedImageResponse(i.Id, i.Url, i.PublicId))
-            .ToList();
-
-        decimal? price = null;
-        bool allowNegotiation = false;
-        string? wantedItem = null;
-        string? wantedItemDesc = null;
-        decimal? minPrice = null;
-        decimal? maxPrice = null;
-
-        switch (product)
-        {
-            case RegularProduct r:
-                price = r.Price;
-                allowNegotiation = r.AllowNegotiation;
-                break;
-
-            case SwapProduct s:
-                wantedItem = s.WantedItemTitle;
-                wantedItemDesc = s.WantedItemDescription;
-                break;
-
-            case WantedProduct w:
-                minPrice = w.DesiredPriceMin;
-                maxPrice = w.DesiredPriceMax;
-                break;
-        }
-
-        return new ProductResponse(
-            Id: product.Id,
-            Type: product.ProductType,
-            Title: product.Title,
-            Description: product.Description,
-            CategoryId: product.CategoryId,
-            Condition: product.Condition,
-            LocationCity: product.LocationCity,
-            LocationCountry: product.LocationCountry,
-            OwnerUserId: product.OwnerUserId,
-            CreatedAt: product.CreatedAt,
-            Price: price,
-            AllowNegotiation: allowNegotiation,
-            WantedItem: wantedItem,
-            WantedItemDescription: wantedItemDesc,
-            MinPrice: minPrice,
-            MaxPrice: maxPrice,
-            Images: images,
-            CoverImageUrl: images.FirstOrDefault()?.Url ?? string.Empty
-        );
-    }
-
-
-    private ProductResponse MapRegularProduct(RegularProduct product)
-    {
-        var images = MapImages(product);
-
-        return new ProductResponse(
-            product.Id,
-            product.ProductType,
-            product.Title,
-            product.Description,
-            product.CategoryId,
-            product.Condition,
-            product.LocationCity,
-            product.LocationCountry,
-            product.OwnerUserId,
-            product.CreatedAt,
-            product.Price,
-            product.AllowNegotiation,
-            null,
-            null,
-            null,
-            null,
-            images,
-            images.FirstOrDefault()?.Url ?? string.Empty
-        );
-    }
-
-    private ProductResponse MapWantedProduct(WantedProduct product)
-    {
-        var images = MapImages(product);
-
-        return new ProductResponse(
-            product.Id,
-            product.ProductType,
-            product.Title,
-            product.Description,
-            product.CategoryId,
-            product.Condition,
-            product.LocationCity,
-            product.LocationCountry,
-            product.OwnerUserId,
-            product.CreatedAt,
-            null,
-            false,
-            null,
-            null,
-            product.DesiredPriceMin,
-            product.DesiredPriceMax,
-            images,
-            images.FirstOrDefault()?.Url ?? string.Empty
-        );
-    }
-
-    private ProductResponse MapSwapProduct(SwapProduct product, int offerCount)
-    {
-        var images = product.ProductImages ?? new List<ProductImage>();
-
-        var offerImages = images.Take(offerCount)
-            .Select(i => new UploadedImageResponse(i.Id, i.Url, i.PublicId))
-            .ToList();
-
-        var wantedImages = images.Skip(offerCount)
-            .Select(i => new UploadedImageResponse(i.Id, i.Url, i.PublicId))
-            .ToList();
-
-        var allImages = offerImages.Concat(wantedImages).ToList();
-
-        return new ProductResponse(
-            product.Id,
-            product.ProductType,
-            product.Title,
-            product.Description,
-            product.CategoryId,
-            product.Condition,
-            product.LocationCity,
-            product.LocationCountry,
-            product.OwnerUserId,
-            product.CreatedAt,
-            null,
-            false,
-            product.WantedItemTitle,
-            product.WantedItemDescription,
-            null,
-            null,
-            allImages,
-            offerImages.FirstOrDefault()?.Url ?? string.Empty
-        );
-    }
-
-    private List<UploadedImageResponse> MapImages(Product product)
-    {
-        return product.ProductImages?
-            .Select(i => new UploadedImageResponse(i.Id, i.Url, i.PublicId))
-            .ToList() ?? new List<UploadedImageResponse>();
-    }
-
-    private static ProductDetailsResponse MapToDetails(Product product)
-    {
-        var images = product.ProductImages
-            .OrderBy(i => i.DisplayOrder)
-            .Select(i => i.Url)
-            .ToList();
-
-        // CategoryId = subcategory when present, root category otherwise
-        var categoryId = product.CategoryId;
-        var categoryName = product.Category.Name;
-
-        //  Type-specific fields 
-        decimal? price = null;
-        bool? allowNegotiation = null;
-        string? wantedItemTitle = null;
-        string? wantedItemDesc = null;
-        string? wantedCondition = null;
-        decimal? desiredPriceMin = null;
-        decimal? desiredPriceMax = null;
-
-        switch (product)
-        {
-            case RegularProduct r:
-                price = r.Price;
-                allowNegotiation = r.AllowNegotiation;
-                break;
-
-            case SwapProduct s:
-                wantedItemTitle = s.WantedItemTitle;
-                wantedItemDesc = s.WantedItemDescription;
-                wantedCondition = FormatCondition(s.WantedCondition);
-                break;
-
-            case WantedProduct w:
-                desiredPriceMin = w.DesiredPriceMin;
-                desiredPriceMax = w.DesiredPriceMax;
-                break;
-        }
-
-        return new ProductDetailsResponse(
-        Id: product.Id,
-        Title: product.Title,
-        Description: product.Description,
-        Type: product.ProductType.ToString(),
-        Condition: FormatCondition(product.Condition),
-        Status: product.Status.ToString().ToLower(),
-
-        LocationCity: product.LocationCity,
-        LocationCountry: product.LocationCountry,
-
-        Price: price,
-        AllowNegotiation: allowNegotiation,
-
-        WantedItemTitle: wantedItemTitle,
-        WantedItemDescription: wantedItemDesc,
-        WantedCondition: wantedCondition,
-
-        DesiredPriceMin: desiredPriceMin,
-        DesiredPriceMax: desiredPriceMax,
-
-        Images: images,
-        CreatedAt: product.CreatedAt,
-        CategoryId: categoryId,
-        CategoryName: categoryName,
-        OwnerUserId: product.OwnerUserId,
-        OwnerUserName: product.Owner.FullName,
-        MemberSince: product.Owner.CreatedAt.ToString("MMMM yyyy")
-);
-    }
-    // Formatter
-    private static string FormatCondition(ProductCondition? condition) => condition switch
-    {
-        ProductCondition.New => "New",
-        ProductCondition.LikeNew => "Like New",
-        ProductCondition.Used => "Used",
-        ProductCondition.Broken => "Broken",
-        _ => condition.ToString()
-    };
-
 }
-#endregion


### PR DESCRIPTION
ProductResponses was defined as a primary constructor record using () .. so it doesn’t have a parameterless constructor.
AutoMapper tries to create the object like  using new ProductResponse() and then set properties=> **which fails** 
 especially when mapping data collected from multiple sources( our situation )  where some values may be null.
Changing it to a record with init properties makes it map safely.