### PR TITLE
Add ForgotPassword and ResetPassword pages and their flow

### DIFF
--- a/src/frontend/src/components/ForgotPasswordPage.tsx
+++ b/src/frontend/src/components/ForgotPasswordPage.tsx
@@ -1,0 +1,210 @@
+import { useState } from "react";
+import { ArrowLeft, Mail, CheckCircle2 } from "lucide-react";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+import { requestPasswordReset } from "../services/passwordResetService";
+
+interface ForgotPasswordPageProps {
+  onNavigateToLogin?: () => void;
+  onCodeSent?: (email: string) => void;
+}
+
+export function ForgotPasswordPage({ onNavigateToLogin, onCodeSent }: ForgotPasswordPageProps) {
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+
+  const validateInput = () => {
+    if (!email.trim()) {
+      setError("Email is required");
+      return false;
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setError("Please enter a valid email address");
+      return false;
+    }
+
+    return true;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateInput()) {
+      return;
+    }
+
+    setIsLoading(true);
+    setError("");
+
+    try {
+      await requestPasswordReset({ email });
+      setShowSuccess(true);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Something went wrong. Please try again.";
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleInputChange = (value: string) => {
+    setEmail(value);
+    if (error) {
+      setError("");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-[#f8f7fc] via-[#fef8fb] to-[#f3f0f9] flex flex-col items-center justify-center p-8 relative overflow-hidden">
+      {/* Decorative Background Elements */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="absolute -top-40 -right-40 w-96 h-96 bg-gradient-to-br from-purple-200/30 to-pink-200/30 rounded-full blur-3xl"></div>
+        <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-gradient-to-tr from-indigo-200/30 to-purple-200/30 rounded-full blur-3xl"></div>
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-gradient-to-r from-purple-100/20 to-pink-100/20 rounded-full blur-3xl"></div>
+      </div>
+
+      {/* Back Button */}
+      <button
+        onClick={onNavigateToLogin}
+        className="absolute top-8 left-8 z-10 flex items-center gap-2 text-gray-600 hover:text-[#4B0082] transition-colors font-medium"
+      >
+        <ArrowLeft className="w-5 h-5" />
+        Back to Login
+      </button>
+
+      {/* Logo Section */}
+      <div className="mb-12 text-center z-10">
+        <div className="inline-block bg-gradient-to-r from-[#4B0082]/5 to-[#8B5CF6]/5 px-12 py-6 rounded-3xl backdrop-blur-sm border border-purple-100/50 shadow-lg">
+          <h1
+            className="text-[64px] font-normal italic text-transparent bg-clip-text bg-gradient-to-r from-[#4B0082] to-[#8B5CF6]"
+            style={{ fontFamily: "'Pacifico', cursive" }}
+          >
+            ReUse
+          </h1>
+        </div>
+      </div>
+
+      {/* Form Card */}
+      <div className="w-full max-w-[480px] bg-white rounded-2xl shadow-2xl shadow-purple-100/50 border border-gray-100/50 p-10 relative z-10 backdrop-blur-xl">
+        {!showSuccess ? (
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {/* Header */}
+            <div className="text-center mb-8">
+              <div className="mx-auto w-16 h-16 bg-gradient-to-br from-[#4B0082]/10 to-[#8B5CF6]/10 rounded-full flex items-center justify-center mb-4">
+                <Mail className="w-8 h-8 text-[#4B0082]" />
+              </div>
+              <h2 className="text-[32px] font-bold text-gray-900 mb-3">Forgot Password?</h2>
+              <p className="text-[15px] text-gray-600 leading-relaxed">
+                No worries! Enter your email address and we'll send you a verification code
+              </p>
+            </div>
+
+            {/* Input */}
+            <div className="space-y-2">
+              <Label htmlFor="email" className="text-[14px] font-medium text-gray-700">
+                Email Address
+              </Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="Enter your email"
+                value={email}
+                onChange={(e) => handleInputChange(e.target.value)}
+                className={`h-12 text-[15px] ${
+                  error
+                    ? "border-red-500 focus-visible:ring-red-500"
+                    : "focus-visible:ring-[#4B0082] focus-visible:border-[#4B0082]"
+                }`}
+              />
+              {error && (
+                <p className="text-red-500 text-[13px] mt-1 flex items-center gap-1">
+                  <span>⚠</span>
+                  {error}
+                </p>
+              )}
+            </div>
+
+            {/* Info Message */}
+            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+              <p className="text-[13px] text-blue-800 leading-relaxed">
+                <span className="font-semibold">Note:</span> A verification code will be sent to
+                your email that you can use to reset your password.
+              </p>
+            </div>
+
+            {/* Submit Button */}
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="w-full bg-gradient-to-r from-[#4B0082] to-[#3d2e7c] text-white text-[16px] font-semibold py-4 rounded-xl hover:from-[#3d2e7c] hover:to-[#2f2360] hover:shadow-xl hover:scale-[1.02] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+            >
+              {isLoading ? (
+                <span className="flex items-center justify-center gap-2">
+                  <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                      fill="none"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                  Sending...
+                </span>
+              ) : (
+                "Send Verification Code"
+              )}
+            </button>
+          </form>
+        ) : (
+          /* Success State */
+          <div className="text-center py-8">
+            <div className="mx-auto w-20 h-20 bg-green-100 rounded-full flex items-center justify-center mb-6">
+              <CheckCircle2 className="w-10 h-10 text-green-600" />
+            </div>
+
+            <h3 className="text-[28px] font-bold text-gray-900 mb-3">Check Your Email!</h3>
+
+            <p className="text-[16px] text-gray-600 mb-2 leading-relaxed">
+              We've sent a verification code to
+            </p>
+            <p className="text-[16px] font-semibold text-[#4B0082] mb-6">{email}</p>
+
+            <div className="bg-gray-50 rounded-lg p-5 mb-6">
+              <p className="text-[14px] text-gray-700 leading-relaxed">
+                Enter the code on the next step to reset your password. The code will expire in 10
+                minutes.
+              </p>
+            </div>
+
+            <button
+              onClick={() => onCodeSent?.(email)}
+              className="w-full bg-gradient-to-r from-[#4B0082] to-[#3d2e7c] text-white text-[16px] font-semibold py-4 rounded-xl hover:from-[#3d2e7c] hover:to-[#2f2360] hover:shadow-xl hover:scale-[1.02] transition-all duration-200 mb-4"
+            >
+              Enter Verification Code
+            </button>
+
+            <button
+              onClick={onNavigateToLogin}
+              className="text-[14px] text-[#4B0082] font-medium hover:underline"
+            >
+              Back to Login
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/ResetPasswordPage.tsx
+++ b/src/frontend/src/components/ResetPasswordPage.tsx
@@ -1,0 +1,307 @@
+import { useState } from "react";
+import { ArrowLeft, Eye, EyeOff, Lock, CheckCircle2, XCircle } from "lucide-react";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+import { resetPassword } from "../services/passwordResetService";
+
+interface ResetPasswordPageProps {
+  resetToken: string;
+  onNavigateToLogin?: () => void;
+  onResetSuccess?: () => void;
+}
+
+const passwordRules = [
+  { id: "length", label: "At least 8 characters", test: (pwd: string) => pwd.length >= 8 },
+  { id: "uppercase", label: "One uppercase letter", test: (pwd: string) => /[A-Z]/.test(pwd) },
+  { id: "lowercase", label: "One lowercase letter", test: (pwd: string) => /[a-z]/.test(pwd) },
+  { id: "number", label: "One number", test: (pwd: string) => /\d/.test(pwd) },
+  {
+    id: "special",
+    label: "One special character",
+    test: (pwd: string) => /[^a-zA-Z0-9]/.test(pwd),
+  },
+];
+
+export function ResetPasswordPage({
+  resetToken,
+  onNavigateToLogin,
+  onResetSuccess,
+}: ResetPasswordPageProps) {
+  const [formData, setFormData] = useState({
+    newPassword: "",
+    confirmPassword: "",
+  });
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitError, setSubmitError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+
+  const validateForm = () => {
+    const newErrors: Record<string, string> = {};
+
+    if (!formData.newPassword) {
+      newErrors.newPassword = "New password is required";
+    } else if (!passwordRules.every((rule) => rule.test(formData.newPassword))) {
+      newErrors.newPassword = "Password does not meet all requirements";
+    }
+
+    if (!formData.confirmPassword) {
+      newErrors.confirmPassword = "Please confirm your password";
+    } else if (formData.newPassword !== formData.confirmPassword) {
+      newErrors.confirmPassword = "Passwords do not match";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsLoading(true);
+    setSubmitError("");
+
+    try {
+      await resetPassword({ resetToken, newPassword: formData.newPassword });
+      setShowSuccess(true);
+      setTimeout(() => {
+        onResetSuccess?.();
+      }, 2000);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to reset password. Please try again.";
+      setSubmitError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleInputChange = (field: keyof typeof formData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+
+    if (errors[field]) {
+      setErrors((prev) => {
+        const newErrors = { ...prev };
+        delete newErrors[field];
+        return newErrors;
+      });
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-[#f8f7fc] via-[#fef8fb] to-[#f3f0f9] flex flex-col items-center justify-center p-8 relative overflow-hidden">
+      {/* Decorative Background Elements */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="absolute -top-40 -right-40 w-96 h-96 bg-gradient-to-br from-purple-200/30 to-pink-200/30 rounded-full blur-3xl"></div>
+        <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-gradient-to-tr from-indigo-200/30 to-purple-200/30 rounded-full blur-3xl"></div>
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-gradient-to-r from-purple-100/20 to-pink-100/20 rounded-full blur-3xl"></div>
+      </div>
+
+      {/* Back Button */}
+      <button
+        onClick={onNavigateToLogin}
+        className="absolute top-8 left-8 z-10 flex items-center gap-2 text-gray-600 hover:text-[#4B0082] transition-colors font-medium"
+      >
+        <ArrowLeft className="w-5 h-5" />
+        Back to Login
+      </button>
+
+      {/* Logo Section */}
+      <div className="mb-12 text-center z-10">
+        <div className="inline-block bg-gradient-to-r from-[#4B0082]/5 to-[#8B5CF6]/5 px-12 py-6 rounded-3xl backdrop-blur-sm border border-purple-100/50 shadow-lg">
+          <h1
+            className="text-[64px] font-normal italic text-transparent bg-clip-text bg-gradient-to-r from-[#4B0082] to-[#8B5CF6]"
+            style={{ fontFamily: "'Pacifico', cursive" }}
+          >
+            ReUse
+          </h1>
+        </div>
+      </div>
+
+      {/* Form Card */}
+      <div className="w-full max-w-[520px] bg-white rounded-2xl shadow-2xl shadow-purple-100/50 border border-gray-100/50 p-10 relative z-10 backdrop-blur-xl">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {/* Header */}
+          <div className="text-center mb-8">
+            <div className="mx-auto w-16 h-16 bg-gradient-to-br from-[#4B0082]/10 to-[#8B5CF6]/10 rounded-full flex items-center justify-center mb-4">
+              <Lock className="w-8 h-8 text-[#4B0082]" />
+            </div>
+            <h2 className="text-[32px] font-bold text-gray-900 mb-3">Reset Password</h2>
+            <p className="text-[15px] text-gray-600 leading-relaxed">
+              Create a strong password to secure your account
+            </p>
+          </div>
+
+          {/* New Password */}
+          <div className="space-y-2">
+            <Label htmlFor="newPassword" className="text-[14px] font-medium text-gray-700">
+              New Password
+            </Label>
+            <div className="relative">
+              <Input
+                id="newPassword"
+                type={showNewPassword ? "text" : "password"}
+                placeholder="Enter new password"
+                value={formData.newPassword}
+                onChange={(e) => handleInputChange("newPassword", e.target.value)}
+                className={`h-12 text-[15px] pr-12 ${
+                  errors.newPassword
+                    ? "border-red-500 focus-visible:ring-red-500"
+                    : "focus-visible:ring-[#4B0082] focus-visible:border-[#4B0082]"
+                }`}
+              />
+              <button
+                type="button"
+                onClick={() => setShowNewPassword(!showNewPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition-colors p-1"
+                aria-label={showNewPassword ? "Hide password" : "Show password"}
+              >
+                {showNewPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+              </button>
+            </div>
+            {errors.newPassword && (
+              <p className="text-red-500 text-[13px] mt-1 flex items-center gap-1">
+                <span>⚠</span>
+                {errors.newPassword}
+              </p>
+            )}
+          </div>
+
+          {/* Password Rules */}
+          <div className="bg-gray-50 rounded-lg p-4 space-y-2">
+            <p className="text-[13px] font-semibold text-gray-700 mb-3">Password must contain:</p>
+            {passwordRules.map((rule) => {
+              const isValid = rule.test(formData.newPassword);
+              return (
+                <div key={rule.id} className="flex items-center gap-2">
+                  {isValid ? (
+                    <CheckCircle2 className="w-4 h-4 text-green-600 flex-shrink-0" />
+                  ) : (
+                    <XCircle className="w-4 h-4 text-gray-300 flex-shrink-0" />
+                  )}
+                  <span
+                    className={`text-[13px] ${
+                      isValid ? "text-green-700 font-medium" : "text-gray-600"
+                    }`}
+                  >
+                    {rule.label}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Confirm Password */}
+          <div className="space-y-2">
+            <Label htmlFor="confirmPassword" className="text-[14px] font-medium text-gray-700">
+              Confirm New Password
+            </Label>
+            <div className="relative">
+              <Input
+                id="confirmPassword"
+                type={showConfirmPassword ? "text" : "password"}
+                placeholder="Re-enter new password"
+                value={formData.confirmPassword}
+                onChange={(e) => handleInputChange("confirmPassword", e.target.value)}
+                className={`h-12 text-[15px] pr-12 ${
+                  errors.confirmPassword
+                    ? "border-red-500 focus-visible:ring-red-500"
+                    : "focus-visible:ring-[#4B0082] focus-visible:border-[#4B0082]"
+                }`}
+              />
+              <button
+                type="button"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition-colors p-1"
+                aria-label={showConfirmPassword ? "Hide password" : "Show password"}
+              >
+                {showConfirmPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+              </button>
+            </div>
+            {errors.confirmPassword && (
+              <p className="text-red-500 text-[13px] mt-1 flex items-center gap-1">
+                <span>⚠</span>
+                {errors.confirmPassword}
+              </p>
+            )}
+          </div>
+
+          {submitError && (
+            <p className="text-red-500 text-[13px] text-center flex items-center justify-center gap-1">
+              <span>⚠</span>
+              {submitError}
+            </p>
+          )}
+
+          {/* Submit Button */}
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full bg-gradient-to-r from-[#4B0082] to-[#3d2e7c] text-white text-[16px] font-semibold py-4 rounded-xl hover:from-[#3d2e7c] hover:to-[#2f2360] hover:shadow-xl hover:scale-[1.02] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+          >
+            {isLoading ? (
+              <span className="flex items-center justify-center gap-2">
+                <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                    fill="none"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                Resetting Password...
+              </span>
+            ) : (
+              "Reset Password"
+            )}
+          </button>
+        </form>
+      </div>
+
+      {/* Success Modal */}
+      {showSuccess && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-6">
+          <div className="bg-white rounded-2xl shadow-2xl p-8 max-w-md w-full">
+            <div className="text-center">
+              <div className="mx-auto w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mb-6">
+                <svg
+                  className="w-8 h-8 text-green-600"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={3}
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
+              </div>
+
+              <h3 className="text-[28px] font-bold text-gray-900 mb-3">
+                Password Reset Successful!
+              </h3>
+              <p className="text-[16px] text-gray-600 mb-2">Your password has been changed.</p>
+              <p className="text-[14px] text-gray-500">Redirecting you to login...</p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/ResetPasswordVerificationPage.tsx
+++ b/src/frontend/src/components/ResetPasswordVerificationPage.tsx
@@ -1,0 +1,237 @@
+import { useState, useEffect, useRef } from "react";
+import { ArrowLeft, ShieldCheck } from "lucide-react";
+import { verifyPasswordReset, requestPasswordReset } from "../services/passwordResetService";
+
+interface ResetPasswordVerificationPageProps {
+  email: string;
+  onNavigateToLogin?: () => void;
+  onVerified?: (resetToken: string) => void;
+}
+
+export function ResetPasswordVerificationPage({
+  email,
+  onNavigateToLogin,
+  onVerified,
+}: ResetPasswordVerificationPageProps) {
+  const [otp, setOtp] = useState(["", "", "", "", "", ""]);
+  const [timeLeft, setTimeLeft] = useState(60);
+  const [canResend, setCanResend] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [error, setError] = useState("");
+
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  useEffect(() => {
+    if (timeLeft > 0) {
+      const timer = setTimeout(() => setTimeLeft(timeLeft - 1), 1000);
+      return () => clearTimeout(timer);
+    } else {
+      setCanResend(true);
+    }
+  }, [timeLeft]);
+
+  const handleChange = (index: number, value: string) => {
+    if (!/^\d*$/.test(value)) return;
+
+    const newOtp = [...otp];
+    newOtp[index] = value;
+    setOtp(newOtp);
+    setError("");
+
+    if (value && index < 5) {
+      inputRefs.current[index + 1]?.focus();
+    }
+
+    if (newOtp.every((d) => d !== "") && index === 5) {
+      handleVerify(newOtp.join(""));
+    }
+  };
+
+  const handleKeyDown = (index: number, e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Backspace" && !otp[index] && index > 0) {
+      inputRefs.current[index - 1]?.focus();
+    }
+  };
+
+  const handlePaste = (e: React.ClipboardEvent) => {
+    e.preventDefault();
+    const pasted = e.clipboardData.getData("text").slice(0, 6);
+
+    if (!/^\d+$/.test(pasted)) return;
+
+    const newOtp = pasted.split("");
+    setOtp(newOtp);
+
+    if (pasted.length === 6) {
+      handleVerify(pasted);
+    }
+  };
+
+  const handleVerify = async (code?: string) => {
+    const verificationCode = code || otp.join("");
+
+    if (verificationCode.length !== 6) {
+      setError("Please enter all 6 digits");
+      return;
+    }
+
+    setIsVerifying(true);
+    setError("");
+
+    try {
+      const { resetToken } = await verifyPasswordReset({
+        email,
+        otp: verificationCode,
+      });
+      onVerified?.(resetToken);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Invalid or expired code. Please try again.";
+      setError(message);
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  const handleResend = async () => {
+    if (!canResend) return;
+
+    try {
+      await requestPasswordReset({ email });
+      setTimeLeft(60);
+      setCanResend(false);
+      setOtp(["", "", "", "", "", ""]);
+      setError("");
+      inputRefs.current[0]?.focus();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to resend code.";
+      setError(message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-[#f8f7fc] via-[#fef8fb] to-[#f3f0f9] flex flex-col items-center justify-center p-8 relative overflow-hidden">
+      {/* Decorative Background Elements */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <div className="absolute -top-40 -right-40 w-96 h-96 bg-gradient-to-br from-purple-200/30 to-pink-200/30 rounded-full blur-3xl"></div>
+        <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-gradient-to-tr from-indigo-200/30 to-purple-200/30 rounded-full blur-3xl"></div>
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-gradient-to-r from-purple-100/20 to-pink-100/20 rounded-full blur-3xl"></div>
+      </div>
+
+      {/* Back Button */}
+      <button
+        onClick={onNavigateToLogin}
+        className="absolute top-8 left-8 z-10 flex items-center gap-2 text-gray-600 hover:text-[#4B0082] transition-colors font-medium"
+      >
+        <ArrowLeft className="w-5 h-5" />
+        Back to Login
+      </button>
+
+      {/* Logo Section */}
+      <div className="mb-12 text-center z-10">
+        <div className="inline-block bg-gradient-to-r from-[#4B0082]/5 to-[#8B5CF6]/5 px-12 py-6 rounded-3xl backdrop-blur-sm border border-purple-100/50 shadow-lg">
+          <h1
+            className="text-[64px] font-normal italic text-transparent bg-clip-text bg-gradient-to-r from-[#4B0082] to-[#8B5CF6]"
+            style={{ fontFamily: "'Pacifico', cursive" }}
+          >
+            ReUse
+          </h1>
+        </div>
+      </div>
+
+      {/* Form Card */}
+      <div className="w-full max-w-[480px] bg-white rounded-2xl shadow-2xl shadow-purple-100/50 border border-gray-100/50 p-10 relative z-10 backdrop-blur-xl">
+        <div className="space-y-6">
+          {/* Header */}
+          <div className="text-center mb-8">
+            <div className="mx-auto w-16 h-16 bg-gradient-to-br from-[#4B0082]/10 to-[#8B5CF6]/10 rounded-full flex items-center justify-center mb-4">
+              <ShieldCheck className="w-8 h-8 text-[#4B0082]" />
+            </div>
+            <h2 className="text-[32px] font-bold text-gray-900 mb-3">Enter Verification Code</h2>
+            <p className="text-[15px] text-gray-600 leading-relaxed">
+              We've sent a 6-digit code to
+            </p>
+            <p className="text-[15px] font-semibold text-[#4B0082]">{email}</p>
+          </div>
+
+          {/* OTP Inputs */}
+          <div className="flex justify-center gap-2" onPaste={handlePaste}>
+            {otp.map((digit, i) => (
+              <input
+                key={i}
+                ref={(el) => {
+                  inputRefs.current[i] = el;
+                }}
+                value={digit}
+                onChange={(e) => handleChange(i, e.target.value)}
+                onKeyDown={(e) => handleKeyDown(i, e)}
+                maxLength={1}
+                inputMode="numeric"
+                className={`w-12 h-14 text-center text-[20px] font-semibold rounded-lg border-2 transition-colors ${
+                  error
+                    ? "border-red-500 focus:ring-2 focus:ring-red-500 focus:outline-none"
+                    : "border-gray-200 focus:border-[#4B0082] focus:ring-2 focus:ring-[#4B0082]/20 focus:outline-none"
+                }`}
+              />
+            ))}
+          </div>
+
+          {error && (
+            <p className="text-red-500 text-[13px] text-center flex items-center justify-center gap-1">
+              <span>⚠</span>
+              {error}
+            </p>
+          )}
+
+          {/* Resend / Timer */}
+          <div className="text-center">
+            {!canResend ? (
+              <p className="text-[14px] text-gray-500">
+                Resend code in <span className="font-semibold text-gray-700">{timeLeft}s</span>
+              </p>
+            ) : (
+              <button
+                onClick={handleResend}
+                className="text-[14px] text-[#4B0082] font-medium hover:underline"
+              >
+                Resend Code
+              </button>
+            )}
+          </div>
+
+          {/* Verify Button */}
+          <button
+            type="button"
+            onClick={() => handleVerify()}
+            disabled={otp.some((d) => !d) || isVerifying}
+            className="w-full bg-gradient-to-r from-[#4B0082] to-[#3d2e7c] text-white text-[16px] font-semibold py-4 rounded-xl hover:from-[#3d2e7c] hover:to-[#2f2360] hover:shadow-xl hover:scale-[1.02] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+          >
+            {isVerifying ? (
+              <span className="flex items-center justify-center gap-2">
+                <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                    fill="none"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                Verifying...
+              </span>
+            ) : (
+              "Verify Code"
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/pages/ForgotPasswordPageWrapper.tsx
+++ b/src/frontend/src/pages/ForgotPasswordPageWrapper.tsx
@@ -1,0 +1,15 @@
+import { useNavigate } from "react-router";
+import { ForgotPasswordPage } from "../components/ForgotPasswordPage";
+
+export default function ForgotPasswordPageWrapper() {
+  const navigate = useNavigate();
+
+  const handleCodeSent = (email: string) => {
+    sessionStorage.setItem("pendingPasswordResetEmail", email);
+    navigate("/reset-password/verify");
+  };
+
+  return (
+    <ForgotPasswordPage onNavigateToLogin={() => navigate("/login")} onCodeSent={handleCodeSent} />
+  );
+}

--- a/src/frontend/src/pages/ResetPasswordPageWrapper.tsx
+++ b/src/frontend/src/pages/ResetPasswordPageWrapper.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router";
+import { ResetPasswordPage } from "../components/ResetPasswordPage";
+
+export default function ResetPasswordPageWrapper() {
+  const navigate = useNavigate();
+  const resetToken = sessionStorage.getItem("pendingPasswordResetToken");
+
+  useEffect(() => {
+    if (!resetToken) {
+      navigate("/forgot-password", { replace: true });
+    }
+  }, [resetToken, navigate]);
+
+  if (!resetToken) {
+    return null;
+  }
+
+  const handleResetSuccess = () => {
+    sessionStorage.removeItem("pendingPasswordResetEmail");
+    sessionStorage.removeItem("pendingPasswordResetToken");
+    navigate("/login", {
+      state: {
+        message: "Password reset successfully. You can now log in.",
+      },
+    });
+  };
+
+  return (
+    <ResetPasswordPage
+      resetToken={resetToken}
+      onNavigateToLogin={() => navigate("/login")}
+      onResetSuccess={handleResetSuccess}
+    />
+  );
+}

--- a/src/frontend/src/pages/ResetPasswordVerificationPageWrapper.tsx
+++ b/src/frontend/src/pages/ResetPasswordVerificationPageWrapper.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router";
+import { ResetPasswordVerificationPage } from "../components/ResetPasswordVerificationPage";
+
+export default function ResetPasswordVerificationPageWrapper() {
+  const navigate = useNavigate();
+  const email = sessionStorage.getItem("pendingPasswordResetEmail");
+
+  useEffect(() => {
+    if (!email) {
+      navigate("/forgot-password", { replace: true });
+    }
+  }, [email, navigate]);
+
+  if (!email) {
+    return null;
+  }
+
+  const handleVerified = (resetToken: string) => {
+    sessionStorage.setItem("pendingPasswordResetToken", resetToken);
+    navigate("/reset-password");
+  };
+
+  return (
+    <ResetPasswordVerificationPage
+      email={email}
+      onNavigateToLogin={() => navigate("/login")}
+      onVerified={handleVerified}
+    />
+  );
+}

--- a/src/frontend/src/routes.tsx
+++ b/src/frontend/src/routes.tsx
@@ -2,6 +2,9 @@ import { createBrowserRouter } from "react-router-dom";
 import LoginPageWrapper from "./pages/LoginPageWrapper";
 import SignUpPageWrapper from "./pages/SignUpPageWrapper";
 import VerificationPageWrapper from "./pages/VerificationPageWrapper";
+import ForgotPasswordPageWrapper from "./pages/ForgotPasswordPageWrapper";
+import ResetPasswordVerificationPageWrapper from "./pages/ResetPasswordVerificationPageWrapper";
+import ResetPasswordPageWrapper from "./pages/ResetPasswordPageWrapper";
 import { GuestRoute } from "./components/GuestRoute";
 // import LoginSuccess from "./pages/LoginSuccess";
 // import { ProtectedRoute } from "./components/ProtectedRoute";
@@ -28,6 +31,18 @@ export const router = createBrowserRouter([
       {
         path: "/verification",
         Component: VerificationPageWrapper,
+      },
+      {
+        path: "/forgot-password",
+        Component: ForgotPasswordPageWrapper,
+      },
+      {
+        path: "/reset-password/verify",
+        Component: ResetPasswordVerificationPageWrapper,
+      },
+      {
+        path: "/reset-password",
+        Component: ResetPasswordPageWrapper,
       },
     ],
   },

--- a/src/frontend/src/services/passwordResetService.ts
+++ b/src/frontend/src/services/passwordResetService.ts
@@ -1,0 +1,62 @@
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+export interface RequestPasswordResetRequest {
+  email: string;
+}
+
+export interface VerifyPasswordResetRequest {
+  email: string;
+  otp: string;
+}
+
+export interface VerifyPasswordResetResponse {
+  resetToken: string;
+}
+
+export interface ResetPasswordRequest {
+  resetToken: string;
+  newPassword: string;
+}
+
+export async function requestPasswordReset(request: RequestPasswordResetRequest) {
+  const res = await fetch(`${BASE_URL}/password-resets`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+
+  if (!res.ok) {
+    const errorData = await res.json();
+    throw new Error(errorData.message || "Failed to send reset code");
+  }
+}
+
+export async function verifyPasswordReset(
+  request: VerifyPasswordResetRequest
+): Promise<VerifyPasswordResetResponse> {
+  const res = await fetch(`${BASE_URL}/password-resets/verify`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+
+  if (!res.ok) {
+    const errorData = await res.json();
+    throw new Error(errorData.message || "OTP verification failed");
+  }
+
+  return res.json() as Promise<VerifyPasswordResetResponse>;
+}
+
+export async function resetPassword(request: ResetPasswordRequest) {
+  const res = await fetch(`${BASE_URL}/password-resets`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+
+  if (!res.ok) {
+    const errorData = await res.json();
+    throw new Error(errorData.message || "Failed to reset password");
+  }
+}


### PR DESCRIPTION
- Adds three guest-only pages: `/forgot-password`, `/reset-password/verify`, `/reset-password`
- Wires all three to the existing endpoints (request -> verify OTP -> reset)

<img width="1920" height="1014" alt="Screenshot from 2026-05-15 14-01-29" src="https://github.com/user-attachments/assets/6579c567-6838-4667-a42b-d4155ff53526" />
<img width="1920" height="1014" alt="Screenshot from 2026-05-15 14-06-32" src="https://github.com/user-attachments/assets/2187b76c-3300-48c0-960f-32d57fc1fa57" />

Closes #39 